### PR TITLE
(#10707) Add os linux to el list

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -63,7 +63,7 @@ class ntp($servers="UNSET",
         $servers_real = $servers
       }
     }
-    centos, redhat, oel: {
+    centos, redhat, oel, linux: {
       $supported  = true
       $pkg_name   = [ "ntp" ]
       $svc_name   = "ntpd"


### PR DESCRIPTION
This patch adds amazon linux support
by adding 'linux' to the list of platforms
that are from the redhat os family.

Currently amazon linux is showing up as
operatingsystem linux. This manifest will
need to be updated when platform detection with
facter works properly in the future.
