### PR TITLE
(#11155) Fix templates so they are ruby-1.9.2 compatible

### DIFF
--- a/templates/ntp.conf.debian.erb
+++ b/templates/ntp.conf.debian.erb
@@ -20,7 +20,7 @@ filegen clockstats file clockstats type day enable
 # pool: <http://www.pool.ntp.org/join.html>
 
 # Managed by puppet class { "ntp": servers => [ ... ] }
-<% servers_real.each do |server| -%>
+<% [servers_real].flatten.each do |server| -%>
 server <%= server %>
 <% end -%>
 

--- a/templates/ntp.conf.el.erb
+++ b/templates/ntp.conf.el.erb
@@ -16,7 +16,7 @@ restrict -6 ::1
 # Please consider joining the pool (http://www.pool.ntp.org/join.html).
 
 # Managed by puppet class { "ntp": servers => [ ... ] }
-<% servers_real.each do |server| -%>
+<% [servers_real].flatten.each do |server| -%>
 server <%= server %>
 <% end -%>
 


### PR DESCRIPTION
The templates had #each methods being called on strings which is not ruby-1.9.2
compatible. Instead, I've converted the string to an array using a pattern that
is still compatible if an array is passed.
