### PR TITLE
(#13595) initialize_everything_for_tests couples modules Puppet ver

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,11 +11,11 @@ RSpec.configure do |c|
     Dir.mkdir(manifestdir)
     FileUtils.touch(File.join(manifestdir, "site.pp"))
     Puppet[:confdir] = @puppetdir
-    Puppet.settings.send(:initialize_everything_for_tests) unless Puppet.version =~ /^2\.6/
+    Puppet.settings.send(:initialize_everything_for_tests) unless Puppet.version =~ /^(2\.6|2\.7\.[0-9][^3-9])/
   end
 
   c.after :each do
-    Puppet.settings.send(:clear_everything_for_tests) unless Puppet.version =~ /^2\.6/
+    Puppet.settings.send(:clear_everything_for_tests) unless Puppet.version =~  /^(2\.6|2\.7\.[0-9][^3-9])/
     FileUtils.remove_entry_secure(@puppetdir)
   end
 


### PR DESCRIPTION
Replace regex used in spec_helper.rb to disallow both Puppet 2.6 and any
2.7 prior to 13.
