### PR TITLE
(#14457) Add FreeBSD support for the NTP class

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -9,4 +9,4 @@ This module has been built and tested using Puppet 2.6.x
  * Enterprise Linux 5
  * Ubuntu 10.04 Lucid
  * Amazon Linux 2011.09 has been tested on 2.7.x with facter version 1.6.2
-
+ * FreeBSD 9.0

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,6 +9,7 @@
 #    - Debian 6.0 Squeeze
 #    - CentOS 5.4
 #    - Amazon Linux 2011.09
+#    - FreeBSD 9.0
 #
 # Parameters:
 #
@@ -78,6 +79,21 @@ class ntp($servers="UNSET",
         $servers_real = $servers
       }
     }
+    freebsd: {
+      $supported  = true
+      $pkg_name   = [".*/net/ntp"]
+      $svc_name   = "ntpd"
+      $config     = "/etc/ntp.conf"
+      $config_tpl = "ntp.conf.freebsd.erb"
+      if ($servers == "UNSET") {
+        $servers_real = [ "0.freebsd.pool.ntp.org iburst maxpoll 9",
+                          "1.freebsd.pool.ntp.org iburst maxpoll 9",
+                          "2.freebsd.pool.ntp.org iburst maxpoll 9",
+                          "3.freebsd.pool.ntp.org iburst maxpoll 9", ]
+      } else {
+        $servers_real = $servers
+      }
+    }
     default: {
       $supported = false
       notify { "${module_name}_unsupported":
@@ -88,7 +104,8 @@ class ntp($servers="UNSET",
 
   if ($supported == true) {
 
-    package { $pkg_name:
+    package { "ntp":
+      name   =>  $pkg_name,
       ensure => $package_ensure,
     }
 

--- a/spec/classes/ntp_spec.rb
+++ b/spec/classes/ntp_spec.rb
@@ -13,6 +13,7 @@ describe 'ntp' do
 
     debianish = ['debian', 'ubuntu']
     redhatish = ['centos', 'redhat', 'oel', 'linux']
+    bsdish    = ['freebsd']
 
     debianish.each do |os|
       describe "for operating system #{os}" do
@@ -50,7 +51,26 @@ describe 'ntp' do
       end
     end
 
-    (redhatish + debianish).each do |os|
+    bsdish.each do |os|
+      describe "for operating system #{os}" do
+
+        let(:params) {{}}
+        let(:facts) { { :operatingsystem => os } }
+
+        it { should contain_service('ntp').with_name('ntpd') }
+        it 'should use the freebsd ntp servers by default' do
+          content = param_value(subject, 'file', '/etc/ntp.conf', 'content')
+          expected_lines = [ 
+            "server 0.freebsd.pool.ntp.org iburst maxpoll 9",
+            "server 1.freebsd.pool.ntp.org iburst maxpoll 9",
+            "server 2.freebsd.pool.ntp.org iburst maxpoll 9",
+            "server 3.freebsd.pool.ntp.org iburst maxpoll 9"]
+          (content.split("\n") & expected_lines).should == expected_lines
+        end
+      end
+    end
+
+    (redhatish + debianish + bsdish).each do |os|
       describe "for operating system #{os}" do
 
         let(:facts) { { :operatingsystem => os } }

--- a/templates/ntp.conf.freebsd.erb
+++ b/templates/ntp.conf.freebsd.erb
@@ -1,0 +1,23 @@
+#
+# $FreeBSD: release/9.0.0/etc/ntp.conf 195652 2009-07-13 05:51:33Z dwmalone $
+#
+# Default NTP servers for the FreeBSD operating system.
+#
+# Don't forget to enable ntpd in /etc/rc.conf with:
+# ntpd_enable="YES"
+#
+# The driftfile is by default /var/db/ntpd.drift, check
+# /etc/defaults/rc.conf on how to change the location.
+#
+#
+# See http://www.pool.ntp.org/ for details. Note, the pool encourages
+# users with a static IP and good upstream NTP servers to add a server
+# to the pool. See http://www.pool.ntp.org/join.html if you are interested.
+#
+# The option `iburst' is used for faster initial synchronisation.
+# The option `maxpoll 9' is used to prevent PLL/FLL flipping on FreeBSD.
+#
+# Managed by puppet class { "ntp": servers => [ ... ] }
+<% [servers_real].flatten.each do |server| -%>
+server <%= server %>
+<% end -%>


### PR DESCRIPTION
This commit adds support for FreeBSD to the NTP class.
