### PR TITLE
(#14497) Add tinker_panic option for ntpd

### DIFF
--- a/templates/ntp.conf.debian.erb
+++ b/templates/ntp.conf.debian.erb
@@ -1,5 +1,11 @@
 # /etc/ntp.conf, configuration for ntpd; see ntp.conf(5) for help
 
+<% if @is_virtual -%>
+# Keep ntpd from panicking in the event of a large clock skew
+# when a VM guest is suspended and resumed.
+tinker panic 0
+
+<% end -%>
 driftfile /var/lib/ntp/ntp.drift
 
 

--- a/templates/ntp.conf.el.erb
+++ b/templates/ntp.conf.el.erb
@@ -1,3 +1,9 @@
+<% if @is_virtual -%>
+# Keep ntpd from panicking in the event of a large clock skew
+# when a VM guest is suspended and resumed.
+tinker panic 0
+
+<% end -%>
 # Permit time synchronization with our time source, but do not
 # permit the source to query or modify the service on this system.
 restrict default kod nomodify notrap nopeer noquery

--- a/templates/ntp.conf.freebsd.erb
+++ b/templates/ntp.conf.freebsd.erb
@@ -18,6 +18,13 @@
 # The option `maxpoll 9' is used to prevent PLL/FLL flipping on FreeBSD.
 #
 # Managed by puppet class { "ntp": servers => [ ... ] }
+<% if @is_virtual -%>
+
+# Keep ntpd from panicking in the event of a large clock skew
+# when a VM guest is suspended and resumed.
+tinker panic 0
+
+<% end -%>
 <% [servers_real].flatten.each do |server| -%>
 server <%= server %>
 <% end -%>


### PR DESCRIPTION
Automatically sets tinker_panic 0 when $is_virtual is true.  This
configuration enables ntpd to cope with large clock skews, such as occur
when a VM guest is suspended and resumed.

More information is available here:

http://www.vmware.com/pdf/vmware_timekeeping.pdf
