### PR TITLE
Support for Scientific Linux

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -65,7 +65,7 @@ class ntp($servers='UNSET',
         $servers_real = $servers
       }
     }
-    centos, redhat, oel, linux, fedora: {
+    centos, redhat, oel, linux, fedora, Scientific: {
       $supported  = true
       $pkg_name   = [ 'ntp' ]
       $svc_name   = 'ntpd'


### PR DESCRIPTION
Scientific Linux is RHEL derived distro produced by (amongst others) Fermilab and CERN.

Tested with SL6.2 x86_64 with puppet-2.7.18-1.el6.noarch and puppet-server-2.7.18-1.el6.noarch from PuppetLabs.
