### PR TITLE
Fix is_virtual check in ntp.conf templates

### DIFF
--- a/templates/ntp.conf.debian.erb
+++ b/templates/ntp.conf.debian.erb
@@ -1,6 +1,6 @@
 # /etc/ntp.conf, configuration for ntpd; see ntp.conf(5) for help
 
-<% if @is_virtual -%>
+<% if @is_virtual == "true" -%>
 # Keep ntpd from panicking in the event of a large clock skew
 # when a VM guest is suspended and resumed.
 tinker panic 0

--- a/templates/ntp.conf.el.erb
+++ b/templates/ntp.conf.el.erb
@@ -1,4 +1,4 @@
-<% if @is_virtual -%>
+<% if @is_virtual == "true" -%>
 # Keep ntpd from panicking in the event of a large clock skew
 # when a VM guest is suspended and resumed.
 tinker panic 0

--- a/templates/ntp.conf.freebsd.erb
+++ b/templates/ntp.conf.freebsd.erb
@@ -18,7 +18,7 @@
 # The option `maxpoll 9' is used to prevent PLL/FLL flipping on FreeBSD.
 #
 # Managed by puppet class { "ntp": servers => [ ... ] }
-<% if @is_virtual -%>
+<% if @is_virtual == "true" -%>
 
 # Keep ntpd from panicking in the event of a large clock skew
 # when a VM guest is suspended and resumed.


### PR DESCRIPTION
is_virtual fact must be checked using a string comparison.

The previous logic would resolve true if the is_virtual fact was
defined. This meant that on servers where is_virtual was defined as
"false", the vm-only snippet was still inserted into the template.
