### PR TITLE
fairly trivial fix to make puppet-lint stop complaining, and a doc update

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -6,7 +6,8 @@ This module has been built and tested using Puppet 2.6.x
 
 # Platforms #
 
- * Enterprise Linux 5
+ * Enterprise Linux 5 (and CentOS 5.4)
  * Ubuntu 10.04 Lucid
  * Amazon Linux 2011.09 has been tested on 2.7.x with facter version 1.6.2
  * FreeBSD 9.0
+ * Debian 6.0 Squeeze

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -105,8 +105,8 @@ class ntp($servers='UNSET',
   if ($supported == true) {
 
     package { 'ntp':
-      name   =>  $pkg_name,
       ensure => $package_ensure,
+      name   => $pkg_name,
     }
 
     file { $config:


### PR DESCRIPTION
Puppet-lint was complaining about "ensure found on line but it's not the
first attribute on line 109".  Trivial fix (swapped the ensure and the
name).

Also, the README didn't mention Debian or CentOS, but the comment block
in init.pp did.  I added both to the README.  I happen to be using this
with Debian unstable, but I haven't tested it extensively enough to say
"yep, this works".  It, however, works for me.
