### PR TITLE
Update pkg_name format for FreeBSD

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -81,7 +81,7 @@ class ntp($servers='UNSET',
     }
     freebsd: {
       $supported  = true
-      $pkg_name   = ['.*/net/ntp']
+      $pkg_name   = ['net/ntp']
       $svc_name   = 'ntpd'
       $config     = '/etc/ntp.conf'
       $config_tpl = 'ntp.conf.freebsd.erb'


### PR DESCRIPTION
Update pkg_name for FreeBSD. Old value not supported by pkgng.
