### PR TITLE
Add restrict parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,6 +18,12 @@
 #                '2.debian.pool.ntp.org iburst',
 #                '3.debian.pool.ntp.org iburst', ]
 #
+#   $restrict = true
+#     Whether to restrict ntp daemons from allowing others to use as a server.
+#
+#   $autoupdate = false
+#     Whether to update the ntp package automatically or not.
+#
 # Actions:
 #
 #  Installs, configures, and manages the ntp service.
@@ -34,6 +40,7 @@
 # [Remember: No empty lines between comments and class definition]
 class ntp($servers='UNSET',
           $ensure='running',
+          $restrict=true,
           $autoupdate=false
 ) {
 

--- a/templates/ntp.conf.debian.erb
+++ b/templates/ntp.conf.debian.erb
@@ -30,6 +30,7 @@ filegen clockstats file clockstats type day enable
 server <%= server %>
 <% end -%>
 
+<% if @restrict -%>
 # Access control configuration; see /usr/share/doc/ntp-doc/html/accopt.html for
 # details.  The web page <http://support.ntp.org/bin/view/Support/AccessRestrictions>
 # might also be helpful.
@@ -50,6 +51,7 @@ restrict ::1
 # cryptographically authenticated.
 #restrict 192.168.123.0 mask 255.255.255.0 notrust
 
+<% end -%>
 
 # If you want to provide time to your local subnet, change the next line.
 # (Again, the address is an example only.)

--- a/templates/ntp.conf.el.erb
+++ b/templates/ntp.conf.el.erb
@@ -4,6 +4,7 @@
 tinker panic 0
 
 <% end -%>
+<% if @restrict -%>
 # Permit time synchronization with our time source, but do not
 # permit the source to query or modify the service on this system.
 restrict default kod nomodify notrap nopeer noquery
@@ -18,6 +19,7 @@ restrict -6 ::1
 # Hosts on local network are less restricted.
 #restrict 192.168.1.0 mask 255.255.255.0 nomodify notrap
 
+<% end -%>
 # Use public servers from the pool.ntp.org project.
 # Please consider joining the pool (http://www.pool.ntp.org/join.html).
 


### PR DESCRIPTION
NTP servers should not restrict themselves to 127.0.0.1, and this commit
adds a `restrict` parameter to enable/disable this configuration block
in the relevent templates.

All tests pass on puppet 2.7.19
