### PR TITLE
Increment Modulefile for 0.2.0 release

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name    'puppetlabs-ntp'
-version '0.1.0'
+version '0.2.0'
 source 'git://github.com/puppetlabs/puppetlabs-ntp'
 author 'Puppet Labs'
 license 'Apache Version 2.0'


### PR DESCRIPTION
0.2.0 is a backwards compatible feature and bug-fix release. Since
0.1.0, support for Amazon Linux was added, fixes for style were
implemented and support was added for tinker_panic. tinker_panic
will default to on when the fact is_virtual is true.
