### PR TITLE
Omit configuration for a local clock as time source if running on a VM.

### DIFF
--- a/templates/ntp.conf.el.erb
+++ b/templates/ntp.conf.el.erb
@@ -35,11 +35,13 @@ server <%= server %>
 #manycastserver 239.255.254.254		# manycast server
 #manycastclient 239.255.254.254 key 42	# manycast client
 
+<% if @is_virtual == "false" -%>
 # Undisciplined Local Clock. This is a fake driver intended for backup
 # and when no outside source of synchronized time is available. 
 server	127.127.1.0	# local clock
 fudge	127.127.1.0 stratum 10	
 
+<% end -%>
 # Drift file.  Put this in a directory which the daemon can write to.
 # No symbolic links allowed, either, since the daemon updates the file
 # by creating a temporary in the same directory and then rename()'ing

--- a/templates/ntp.conf.suse.erb
+++ b/templates/ntp.conf.suse.erb
@@ -29,6 +29,7 @@
 ##
 # server 127.127.8.0 mode 5 prefer
 
+<% if @is_virtual == "false" -%>
 ##
 ## Undisciplined Local Clock. This is a fake driver intended for backup
 ## and when no outside source of synchronized time is available.
@@ -36,6 +37,7 @@
 server 127.127.1.0		# local clock (LCL)
 fudge  127.127.1.0 stratum 10	# LCL is unsynchronized
 
+<% end -%>
 # Managed by puppet class { "ntp": servers => [ ... ] }
 <% [servers_real].flatten.each do |server| -%>
 server <%= server %>


### PR DESCRIPTION
Quoting http://kb.vmware.com/selfservice/microsites/search.do?language=en_US&cmd=displayKC&externalId=1006427
'It is also important not to use the local clock as a time source, often referred to as the Undisciplined Local Clock.'
