### PR TITLE
Add test for virtual machines and local clocks

### DIFF
--- a/spec/classes/ntp_spec.rb
+++ b/spec/classes/ntp_spec.rb
@@ -88,6 +88,22 @@ describe 'ntp' do
 
     end
 
+    describe "for virtual machines" do
+
+      let(:params) {{}}
+      let(:facts) { { :operatingsystem => 'Archlinux',
+                      :osfamily        => 'Linux',
+                      :isvirtual       => 'false' } }
+
+      it 'should not use local clock as a time source' do
+        content = param_value(subject, 'file', '/etc/ntp.conf', 'content')
+        expected_lines = [
+          'server  127.127.1.0  # local clock',
+          'fudge  127.127.1.0 stratum 10' ]
+        (content.split("\n") & expected_lines).should_not == expected_lines
+      end
+    end
+
     describe "for operating system Archlinux" do
 
       let(:params) {{}}


### PR DESCRIPTION
This commit provides a spec test for pull request #49 and commit
01273c53f1cf2015c3ff5a9f704828225d900e03 which specifies that virtual
machines should not use the local clock. This test attempts to protect
against a regression on that statement.
