### PR TITLE
Added panic parameter to ntp class

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -49,12 +49,24 @@ class ntp($servers='UNSET',
           $ensure='running',
           $enable=true,
           $restrict=true,
+          $panic=undef,
           $config_template=undef,
           $autoupdate=false
 ) {
 
   if ! ($ensure in [ 'running', 'stopped' ]) {
     fail('ensure parameter must be running or stopped')
+  }
+
+  if $panic == undef {
+    $tinker_panic = $::is_virtual ? {
+      'true'  => false,
+      default => true,
+    }
+  } elsif $panic == true or $panic == false{
+    $tinker_panic = $panic
+  } else {
+    fail('panic parameter must be undef, true or false')
   }
 
   if $autoupdate == true {

--- a/spec/classes/ntp_spec.rb
+++ b/spec/classes/ntp_spec.rb
@@ -150,6 +150,46 @@ describe 'ntp' do
           expected_lines = ['server foobar']
           (content.split("\n") & expected_lines).should == expected_lines
         end
+
+        describe "with is_virtual => true" do
+          let(:facts) { { :osfamily   => osfamily,
+                          :is_virtual => 'true' } }
+          it 'should set tinker panic 0' do
+            content = param_value(subject, 'file', '/etc/ntp.conf', 'content')
+            expected_lines = ['tinker panic 0']
+            (content.split("\n") & expected_lines).should == expected_lines
+          end
+        end
+
+        describe "with panic => false" do
+          let(:params) { { :panic => false } }
+          let(:facts) { { :osfamily => osfamily } }
+          it 'should set tinker panic 0' do
+            content = param_value(subject, 'file', '/etc/ntp.conf', 'content')
+            expected_lines = ['tinker panic 0']
+            (content.split("\n") & expected_lines).should == expected_lines
+          end
+        end
+
+        describe "with is_virtual => false" do
+          let(:facts) { { :osfamily   => osfamily,
+                          :is_virtual => 'false'} }
+          it 'should not set tinker panic 0' do
+            content = param_value(subject, 'file', '/etc/ntp.conf', 'content')
+            expected_lines = ['tinker panic 0']
+            (content.split("\n") & expected_lines).should_not == expected_lines
+          end
+        end
+
+        describe "with panic => true" do
+          let(:params) { { :panic => true } }
+          let(:facts) { { :osfamily => osfamily } }
+          it 'should not set tinker panic 0' do
+            content = param_value(subject, 'file', '/etc/ntp.conf', 'content')
+            expected_lines = ['tinker panic 0']
+            (content.split("\n") & expected_lines).should_not == expected_lines
+          end
+        end
       end
     end
   end

--- a/templates/ntp.conf.debian.erb
+++ b/templates/ntp.conf.debian.erb
@@ -1,6 +1,6 @@
 # /etc/ntp.conf, configuration for ntpd; see ntp.conf(5) for help
 
-<% if @is_virtual == "true" -%>
+<% if @tinker_panic == false -%>
 # Keep ntpd from panicking in the event of a large clock skew
 # when a VM guest is suspended and resumed.
 tinker panic 0

--- a/templates/ntp.conf.el.erb
+++ b/templates/ntp.conf.el.erb
@@ -1,4 +1,4 @@
-<% if @is_virtual == "true" -%>
+<% if @tinker_panic == false -%>
 # Keep ntpd from panicking in the event of a large clock skew
 # when a VM guest is suspended and resumed.
 tinker panic 0

--- a/templates/ntp.conf.freebsd.erb
+++ b/templates/ntp.conf.freebsd.erb
@@ -18,7 +18,7 @@
 # The option `maxpoll 9' is used to prevent PLL/FLL flipping on FreeBSD.
 #
 # Managed by puppet class { "ntp": servers => [ ... ] }
-<% if @is_virtual == "true" -%>
+<% if @tinker_panic == false -%>
 
 # Keep ntpd from panicking in the event of a large clock skew
 # when a VM guest is suspended and resumed.

--- a/templates/ntp.conf.suse.erb
+++ b/templates/ntp.conf.suse.erb
@@ -43,7 +43,7 @@ fudge  127.127.1.0 stratum 10	# LCL is unsynchronized
 server <%= server %>
 <% end -%>
 
-<% if @is_virtual == "true" -%>
+<% if @tinker_panic == false -%>
 # Keep ntpd from panicking in the event of a large clock skew
 # when a VM guest is suspended and resumed.
 tinker panic 0


### PR DESCRIPTION
This change adds the panic parameter to the ntp class so that it can be
overwritten. The reason for this change is that physical hardware might
also have a large clock skew, not only virtual hardware. In these rare
cases, it would be useful to support enabling: tinker panic 0.

The change to the class still made all the rspec tests pass, so it 
should not introduce any regressions. More rspec tests were also added
to exercise the new code paths introduced.
