### PR TITLE
fix panic parameter in virtual machines

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,7 +9,7 @@ class ntp::params {
 
   # On virtual machines allow large clock skews.
   $panic = $::is_virtual ? {
-    true    => false,
+    'true'  => false,
     default => true,
   }
 

--- a/spec/classes/ntp_config_spec.rb
+++ b/spec/classes/ntp_config_spec.rb
@@ -109,7 +109,7 @@ describe 'ntp::config' do
 
       let(:params) {{}}
       let(:facts) {{ :osfamily        => 'Archlinux',
-                     :is_virtual      => true }}
+                     :is_virtual      => 'true' }}
 
       it 'should not use local clock as a time source' do
         content = param_value(subject, 'file', '/etc/ntp.conf', 'content')
@@ -131,7 +131,7 @@ describe 'ntp::config' do
 
       let(:params) {{}}
       let(:facts) {{ :osfamily        => 'Archlinux',
-                     :is_virtual      => false }}
+                     :is_virtual      => 'false' }}
 
       it 'disallows large clock skews' do
         content = param_value(subject, 'file', '/etc/ntp.conf', 'content')


### PR DESCRIPTION
As facts are always strings, quoting is required here.
