### PR TITLE
Remove variables in non-paramaterized classes.

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,21 +1,8 @@
 #
 class ntp::config {
 
-  $config            = $ntp::config
-  $config_template   = $ntp::config_template
-  $driftfile         = $ntp::driftfile
-  $keys_enable       = $ntp::keys_enable
-  $keys_file         = $ntp::keys_file
-  $keys_controlkey   = $ntp::keys_controlkey
-  $keys_requestkey   = $ntp::keys_requestkey
-  $keys_trusted      = $ntp::keys_trusted
-  $panic             = $ntp::panic
-  $preferred_servers = $ntp::preferred_servers
-  $restrict          = $ntp::restrict
-  $servers           = $ntp::servers
-
-  if $keys_enable {
-    $directory = dirname($keys_file)
+  if $ntp::keys_enable {
+    $directory = dirname($ntp::keys_file)
     file { $directory:
       ensure  => directory,
       owner   => 0,
@@ -25,12 +12,12 @@ class ntp::config {
     }
   }
 
-  file { $config:
+  file { $ntp::config:
     ensure  => file,
     owner   => 0,
     group   => 0,
     mode    => '0644',
-    content => template($config_template),
+    content => template($ntp::config_template),
   }
 
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,12 +1,9 @@
 #
 class ntp::install {
 
-  $package_ensure = $ntp::package_ensure
-  $package_name   = $ntp::package_name
-
   package { 'ntp':
-    ensure => $package_ensure,
-    name   => $package_name,
+    ensure => $ntp::package_ensure,
+    name   => $ntp::package_name,
   }
 
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,20 +1,15 @@
 #
 class ntp::service {
 
-  $service_enable = $ntp::service_enable
-  $service_ensure = $ntp::service_ensure
-  $service_manage = $ntp::service_manage
-  $service_name   = $ntp::service_name
-
-  if ! ($service_ensure in [ 'running', 'stopped' ]) {
+  if ! ($ntp::service_ensure in [ 'running', 'stopped' ]) {
     fail('service_ensure parameter must be running or stopped')
   }
 
-  if $service_manage == true {
+  if $ntp::service_manage == true {
     service { 'ntp':
-      ensure     => $service_ensure,
-      enable     => $service_enable,
-      name       => $service_name,
+      ensure     => $ntp::service_ensure,
+      enable     => $ntp::service_enable,
+      name       => $ntp::service_name,
       hasstatus  => true,
       hasrestart => true,
     }

--- a/templates/ntp.conf.erb
+++ b/templates/ntp.conf.erb
@@ -1,22 +1,22 @@
 # ntp.conf: Managed by puppet.
 #
-<% if @panic == false -%>
+<% if scope.lookupvar('ntp::panic') == false -%>
 # Keep ntpd from panicking in the event of a large clock skew
 # when a VM guest is suspended and resumed.
 tinker panic 0
 <% end -%>
 
-<% if @restrict != [] -%>
+<% if scope.lookupvar('ntp::restrict') != [] -%>
 # Permit time synchronization with our time source, but do not'
 # permit the source to query or modify the service on this system.'
-<% @restrict.flatten.each do |restrict| -%>
+<% scope.lookupvar('ntp::restrict').flatten.each do |restrict| -%>
 <%= restrict %>
 <% end %>
 <% end -%>
 
 # Servers
-<% [@servers].flatten.each do |server| -%>
-server <%= server %><% if @preferred_servers.include?(server) -%> prefer<% end %>
+<% scope.lookupvar('ntp::servers').flatten.each do |server| -%>
+server <%= server %><% if scope.lookupvar('ntp::preferred_servers').include?(server) -%> prefer<% end %>
 <% end -%>
 
 <% if scope.lookupvar('::is_virtual') == "false" -%>
@@ -27,17 +27,17 @@ fudge	127.127.1.0 stratum 10
 <% end -%>
 
 # Driftfile.
-driftfile <%= @driftfile %>
+driftfile <%= scope.lookupvar('ntp::driftfile') %>
 
-<% if @keys_enable -%>
-keys <%= @keys_file %>
-<% unless @keys_trusted.empty? -%>
-trustedkey <%= @keys_trusted.join(' ') %>
+<% if scope.lookupvar('ntp::keys_enable') -%>
+keys <%= scope.lookupvar('ntp::keys_file') %>
+<% unless scope.lookupvar('ntp::keys_trusted').empty? -%>
+trustedkey <%= scope.lookupvar('ntp::keys_trusted').join(' ') %>
 <% end -%>
-<% if @keys_requestkey != '' -%>
-requestkey <%= @keys_requestkey %>
+<% if scope.lookupvar('ntp::keys_requestkey') != '' -%>
+requestkey <%= scope.lookupvar('ntp::keys_requestkey') %>
 <% end -%>
-<% if @keys_controlkey != '' -%>
-controlkey <%= @keys_controlkey %>
+<% if scope.lookupvar('ntp::keys_controlkey') != '' -%>
+controlkey <%= scope.lookupvar('ntp::keys_controlkey') %>
 <% end -%>
 <% end -%>


### PR DESCRIPTION
This just adds extra variables that serve no real purpose
and hide the origin of the data we're dealing with.  Convert
this to direct calls.
