### PR TITLE
cleanup include and ordering of classes

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -44,17 +44,13 @@ class ntp (
     notice('autoupdate parameter has been deprecated and replaced with package_ensure.  Set this to latest for the same behavior as autoupdate => true.')
   }
 
-  include '::ntp::install'
-  include '::ntp::config'
-  include '::ntp::service'
-
   # Anchor this as per #8040 - this ensures that classes won't float off and
   # mess everything up.  You can read about this at:
   # http://docs.puppetlabs.com/puppet/2.7/reference/lang_containment.html#known-issues
-  anchor { 'ntp::begin': }
+  anchor { 'ntp::begin': } ->
+  class { '::ntp::install': } ->
+  class { '::ntp::config': } ~>
+  class { '::ntp::service': } ->
   anchor { 'ntp::end': }
-
-  Anchor['ntp::begin'] -> Class['::ntp::install'] -> Class['::ntp::config']
-    ~> Class['::ntp::service'] -> Anchor['ntp::end']
 
 }


### PR DESCRIPTION
we do this by removing the explicit include statements and moving the
classes, in the proopper order between the anchors
