### PR TITLE
Prepend restrict when using `restrict`.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -162,7 +162,8 @@ that also appears in the servers list.
 
 ####`restrict`
 
-This sets the restrict options in the ntp configuration.
+This sets the restrict options in the ntp configuration.  The lines are
+preappended with restrict so you just need to list the rest of the restriction.
 
 ####`servers`
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,10 +9,10 @@ class ntp::params {
   $package_ensure    = 'present'
   $preferred_servers = []
   $restrict          = [
-    'restrict default kod nomodify notrap nopeer noquery',
-    'restrict -6 default kod nomodify notrap nopeer noquery',
-    'restrict 127.0.0.1',
-    'restrict -6 ::1',
+    'default kod nomodify notrap nopeer noquery',
+    '-6 default kod nomodify notrap nopeer noquery',
+    '127.0.0.1',
+    '-6 ::1',
   ]
   $service_enable    = true
   $service_ensure    = 'running'

--- a/templates/ntp.conf.erb
+++ b/templates/ntp.conf.erb
@@ -10,7 +10,7 @@ tinker panic 0
 # Permit time synchronization with our time source, but do not'
 # permit the source to query or modify the service on this system.'
 <% @restrict.flatten.each do |restrict| -%>
-<%= restrict %>
+restrict <%= restrict %>
 <% end %>
 <% end -%>
 


### PR DESCRIPTION
This updates the template to preappend restrict so users don't have to
repeat it constantly and ensures this param cannot be used to sneak in
other non-restriction lines.

This PR dedicated to Zach.
