### PR TITLE
Added $autosync option; allows Puppet to autosync the date/time on a ser...

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,4 +1,5 @@
 class ntp (
+  $autosync          = $ntp::params::autosync,
   $autoupdate        = $ntp::params::autoupdate,
   $config            = $ntp::params::config,
   $config_template   = $ntp::params::config_template,
@@ -21,6 +22,7 @@ class ntp (
   $udlc              = $ntp::params::udlc
 ) inherits ntp::params {
 
+  validate_bool($autosync)
   validate_absolute_path($config)
   validate_string($config_template)
   validate_absolute_path($driftfile)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,5 +1,6 @@
 class ntp::params {
 
+  $autosync          = false
   $autoupdate        = false
   $config_template   = 'ntp/ntp.conf.erb'
   $keys_enable       = false

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -15,4 +15,11 @@ class ntp::service inherits ntp {
     }
   }
 
+  $use_servers = join($servers, " ")
+  if $autosync {
+    exec { "/usr/sbin/ntpdate -u ${use_servers} >> /dev/null":
+     refreshonly => true
+    }
+  }
+
 }

--- a/spec/acceptance/ntp_autosync_spec.rb
+++ b/spec/acceptance/ntp_autosync_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper_acceptance'
+
+case fact('osfamily')
+when 'RedHat', 'FreeBSD', 'Linux', 'Gentoo'
+  servicename = 'ntpd'
+else
+  servicename = 'ntp'
+end
+
+describe 'ntp::autosync parameter' do
+  it 'sets up ntp' do
+    apply_manifest("class { 'ntp': }", :catch_failures => true)
+  end
+
+  it 'sets the clock incorrectly and breaks ntp' do
+    shell("puppet resource service #{servicename} ensure=stopped")
+    shell('ntpdate time.nist.gov')
+    #shell('time=`date --date="1 hour ago" +%T` ; date --set "${time}"')
+    shell("date -s +'-1 hour'")
+    shell('rm /etc/ntp.conf')
+  end
+
+  it 'runs with autosync => true' do
+    pp = <<-EOS
+      class { 'ntp':
+        autosync => true,
+      }
+    EOS
+
+    apply_manifest(pp, :catch_failures => true) do |r|
+      expect(r.stdout).to match(/Exec.*ntpdate/)
+    end
+  end
+
+  it 'sets the clock incorrectly and breaks ntp' do
+    shell("puppet resource service #{servicename} ensure=stopped")
+    shell('ntpdate time.nist.gov')
+    #shell('time=`date --date="1 hour ago" +%T` ; date --set "${time}"')
+    shell("date -s +'-1 hour'")
+    shell('rm /etc/ntp.conf')
+  end
+
+  it 'runs with autosync => false' do
+    pp = <<-EOS
+      class { 'ntp':
+        autosync => false,
+      }
+    EOS
+
+    apply_manifest(pp, :catch_failures => true) do |r|
+      expect(r.stdout).to_not match(/Exec.*ntpdate/)
+    end
+  end
+
+end


### PR DESCRIPTION
Allows Puppet to autosync the date/time on a server when the date/time has drifted too much for ntpd to adjust it.