### PR TITLE
Support running tests against Puppet Enterprise

### DIFF
--- a/spec/acceptance/basic_spec.rb
+++ b/spec/acceptance/basic_spec.rb
@@ -1,7 +1,0 @@
-require 'spec_helper_acceptance'
-
-describe 'basic tests' do
-  it 'copied the module' do
-    shell('ls /etc/puppet/modules/ntp/Modulefile', {:acceptable_exit_codes => 0})
-  end
-end

--- a/spec/acceptance/ntp_parameters_spec.rb
+++ b/spec/acceptance/ntp_parameters_spec.rb
@@ -32,8 +32,9 @@ describe "ntp class:" do
 
   describe 'config_template' do
     it 'sets up template' do
-      shell('mkdir -p /etc/puppet/modules/test/templates')
-      shell('echo "testcontent" >> /etc/puppet/modules/test/templates/ntp.conf')
+      modulepath = default['distmoduledir']
+      shell("mkdir -p #{modulepath}/test/templates")
+      shell("echo 'testcontent' >> #{modulepath}/test/templates/ntp.conf")
     end
 
     it 'sets the ntp.conf location' do


### PR DESCRIPTION
This removes FOSS specific pathing in the ntp_parameters_specs and
removes the basic_spec entirely (both contained FOSS specific paths but
the basic test seemed more like a sanity check on the testing tools)
