### PR TITLE
Workaround for stdlib 3.2 in PE3.x.

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -2,7 +2,8 @@
 class ntp::config inherits ntp {
 
   if $keys_enable {
-    $directory = dirname($keys_file)
+    # Workaround for the lack of dirname() in stdlib 3.2.
+    $directory = inline_template('<%= File.dirname(keys_file) %>')
     file { $directory:
       ensure  => directory,
       owner   => 0,


### PR DESCRIPTION
Switch from dirname() to an inline_template that calls File.dirname
directly.
