### PR TITLE
Remove unnecessary apostrophes in template

### DIFF
--- a/templates/ntp.conf.erb
+++ b/templates/ntp.conf.erb
@@ -11,8 +11,8 @@ disable monitor
 <% end -%>
 
 <% if @restrict != [] -%>
-# Permit time synchronization with our time source, but do not'
-# permit the source to query or modify the service on this system.'
+# Permit time synchronization with our time source, but do not
+# permit the source to query or modify the service on this system.
 <% @restrict.flatten.each do |restrict| -%>
 restrict <%= restrict %>
 <% end %>


### PR DESCRIPTION
Removes unnecessary apostrophes in template file introduced in 52ff81b7d0debb91f0aa86c5933aa90d5008ded5
