### PR TITLE
Release 3.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
-##2014-03-04 - Supported Release 3.0.x
+##2014-03-04 - Supported Release 3.0.3
 ###Summary
-
-####Features
+This is a supported release. Correct stdlib compatibility
 
 ####Bugfixes
+- Remove `dirname()` call for correct stdlib compatibility.
+- Improved tests
 
 ####Known Bugs
 * No known bugs

--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name    'puppetlabs-ntp'
-version '3.0.2'
+version '3.0.3'
 source 'git://github.com/puppetlabs/puppetlabs-ntp'
 author 'Puppet Labs'
 license 'Apache Version 2.0'


### PR DESCRIPTION
### Summary

This is a supported release. Correct stdlib compatibility
#### Bugfixes
- Remove `dirname()` call for correct stdlib compatibility.
- Improved tests
#### Known Bugs
- No known bugs
