### PR TITLE
No Undisciplined Local Clock by default

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -193,8 +193,7 @@ Selects the name of the ntp service for Puppet to manage.
 
 ####`udlc`
 
-Enables configs for undisciplined local clock, regardless of
-status as a virtual machine. 
+Enables configs for undisciplined local clock.
 
 
 ##Limitations

--- a/templates/ntp.conf.erb
+++ b/templates/ntp.conf.erb
@@ -22,7 +22,7 @@ restrict <%= restrict %>
 server <%= server %><% if @preferred_servers.include?(server) -%> prefer<% end %>
 <% end -%>
 
-<% if scope.lookupvar('::is_virtual') == "false" or @udlc -%>
+<% if @udlc -%>
 # Undisciplined Local Clock. This is a fake driver intended for backup
 # and when no outside source of synchronized time is available. 
 server	127.127.1.0 


### PR DESCRIPTION
Do not enable UDLC by default on baremetal (non-virtual) systems.
Baremetal systems might not serve as time-source at all.
UDLC is not a back-up for leaf-nodes (ntp client only)!

See http://support.ntp.org/bin/view/Support/UndisciplinedLocalClock