### PR TITLE
Introduce the iburst_enable parameter to use "iburst" option

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -128,6 +128,10 @@ Disables monitoring of ntp.
 
 Sets the location of the drift file for ntp.
 
+####`iburst_enable`
+
+Set the iburst option in the ntp configuration. If enabled the option is set for every ntp peer.
+
 ####`keys_controlkey`
 
 The key to use as the control key.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,6 +4,7 @@ class ntp (
   $config_template   = $ntp::params::config_template,
   $disable_monitor   = $ntp::params::disable_monitor,
   $driftfile         = $ntp::params::driftfile,
+  $iburst_enable     = $ntp::params::iburst_enable,
   $keys_enable       = $ntp::params::keys_enable,
   $keys_file         = $ntp::params::keys_file,
   $keys_controlkey   = $ntp::params::keys_controlkey,
@@ -26,6 +27,7 @@ class ntp (
   validate_string($config_template)
   validate_bool($disable_monitor)
   validate_absolute_path($driftfile)
+  validate_bool($iburst_enable)
   validate_bool($keys_enable)
   validate_re($keys_controlkey, ['^\d+$', ''])
   validate_re($keys_requestkey, ['^\d+$', ''])

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,20 +22,21 @@ class ntp::params {
 
   case $::osfamily {
     'AIX': {
-      $config = '/etc/ntp.conf'
-      $keysfile = '/etc/ntp.keys'
-      $driftfile = '/etc/ntp.drift'
-      $package_name = [ 'bos.net.tcp.client' ]
+      $config        = '/etc/ntp.conf'
+      $keysfile      = '/etc/ntp.keys'
+      $driftfile     = '/etc/ntp.drift'
+      $package_name  = [ 'bos.net.tcp.client' ]
       $restrict          = [
         'default nomodify notrap nopeer noquery',
         '127.0.0.1',
       ]
-      $service_name = 'xntpd'
-      $servers = [
-        '0.debian.pool.ntp.org iburst',
-        '1.debian.pool.ntp.org iburst',
-        '2.debian.pool.ntp.org iburst',
-        '3.debian.pool.ntp.org iburst',
+      $service_name  = 'xntpd'
+      $iburst_enable = true
+      $servers       = [
+        '0.debian.pool.ntp.org',
+        '1.debian.pool.ntp.org',
+        '2.debian.pool.ntp.org',
+        '3.debian.pool.ntp.org',
       ]
     }
     'Debian': {
@@ -50,11 +51,12 @@ class ntp::params {
         '-6 ::1',
       ]
       $service_name    = 'ntp'
+      $iburst_enable   = true
       $servers         = [
-        '0.debian.pool.ntp.org iburst',
-        '1.debian.pool.ntp.org iburst',
-        '2.debian.pool.ntp.org iburst',
-        '3.debian.pool.ntp.org iburst',
+        '0.debian.pool.ntp.org',
+        '1.debian.pool.ntp.org',
+        '2.debian.pool.ntp.org',
+        '3.debian.pool.ntp.org',
       ]
     }
     'RedHat': {
@@ -69,6 +71,7 @@ class ntp::params {
         '-6 ::1',
       ]
       $service_name    = 'ntpd'
+      $iburst_enable   = false
       $servers         = [
         '0.centos.pool.ntp.org',
         '1.centos.pool.ntp.org',
@@ -87,6 +90,7 @@ class ntp::params {
         '-6 ::1',
       ]
       $service_name    = 'ntp'
+      $iburst_enable   = false
       $servers         = [
         '0.opensuse.pool.ntp.org',
         '1.opensuse.pool.ntp.org',
@@ -106,11 +110,12 @@ class ntp::params {
         '-6 ::1',
       ]
       $service_name    = 'ntpd'
+      $iburst_enable   = true
       $servers         = [
-        '0.freebsd.pool.ntp.org iburst maxpoll 9',
-        '1.freebsd.pool.ntp.org iburst maxpoll 9',
-        '2.freebsd.pool.ntp.org iburst maxpoll 9',
-        '3.freebsd.pool.ntp.org iburst maxpoll 9',
+        '0.freebsd.pool.ntp.org maxpoll 9',
+        '1.freebsd.pool.ntp.org maxpoll 9',
+        '2.freebsd.pool.ntp.org maxpoll 9',
+        '3.freebsd.pool.ntp.org maxpoll 9',
       ]
     }
     'Archlinux': {
@@ -125,6 +130,7 @@ class ntp::params {
         '-6 ::1',
       ]
       $service_name    = 'ntpd'
+      $iburst_enable   = false
       $servers         = [
         '0.pool.ntp.org',
         '1.pool.ntp.org',
@@ -144,6 +150,7 @@ class ntp::params {
         '-6 ::1',
       ]
       $service_name    = 'ntpd'
+      $iburst_enable   = false
       $servers         = [
         '0.gentoo.pool.ntp.org',
         '1.gentoo.pool.ntp.org',
@@ -167,6 +174,7 @@ class ntp::params {
             '-6 ::1',
           ]
           $service_name    = 'ntpd'
+          $iburst_enable   = false
           $servers         = [
             '0.gentoo.pool.ntp.org',
             '1.gentoo.pool.ntp.org',

--- a/spec/acceptance/ntp_config_spec.rb
+++ b/spec/acceptance/ntp_config_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper_acceptance'
 
 case fact('osfamily')
 when 'FreeBSD'
-  line = '0.freebsd.pool.ntp.org iburst maxpoll 9'
+  line = '0.freebsd.pool.ntp.org maxpoll 9 iburst'
 when 'Debian'
   line = '0.debian.pool.ntp.org iburst'
 when 'RedHat'

--- a/spec/classes/ntp_spec.rb
+++ b/spec/classes/ntp_spec.rb
@@ -155,6 +155,32 @@ describe 'ntp' do
           end
         end
       end
+
+      describe 'with parameter iburst_enable' do
+        context 'when set to true' do
+          let(:params) {{
+            :iburst_enable => true,
+          }}
+
+          it do
+            should contain_file('/etc/ntp.conf').with({
+            'content' => /iburst\n/,
+            })
+          end
+        end
+
+        context 'when set to false' do
+          let(:params) {{
+            :iburst_enable => false,
+          }}
+
+          it do
+            should_not contain_file('/etc/ntp.conf').with({
+              'content' => /iburst\n/,
+            })
+          end
+        end
+      end
     end
 
     context 'ntp::config' do
@@ -184,7 +210,7 @@ describe 'ntp' do
 
         it 'uses the debian ntp servers by default' do
           should contain_file('/etc/ntp.conf').with({
-            'content' => /server \d.debian.pool.ntp.org iburst/,
+            'content' => /server \d.debian.pool.ntp.org iburst\n/,
           })
         end
       end
@@ -214,7 +240,7 @@ describe 'ntp' do
 
         it 'uses the freebsd ntp servers by default' do
           should contain_file('/etc/ntp.conf').with({
-            'content' => /server \d.freebsd.pool.ntp.org iburst maxpoll 9/,
+            'content' => /server \d.freebsd.pool.ntp.org maxpoll 9 iburst/,
           })
         end
       end

--- a/templates/ntp.conf.erb
+++ b/templates/ntp.conf.erb
@@ -19,7 +19,7 @@ restrict <%= restrict %>
 <% end -%>
 
 <% [@servers].flatten.each do |server| -%>
-server <%= server %><% if @preferred_servers.include?(server) -%> prefer<% end %>
+server <%= server %><% if @preferred_servers.include?(server) -%> prefer<% end %><% if @iburst_enable == true -%> iburst<% end %>
 <% end -%>
 
 <% if scope.lookupvar('::is_virtual') == "false" or @udlc -%>


### PR DESCRIPTION
Hi,

this pull request makes the option "iburst" configurable. We use Debian and CentOS server and until now the CentOS server doesn't use "iburst" while the Debian server have it turned on by default.

The old default  behavior is preserved if no iburst_enable parameter is set.

The RSpec tests run successful but unfortunately i was not able to run the rspec-system tests. 

Best wishes,
Matthias  
