### PR TITLE
Typo fix.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,7 +22,7 @@ class ntp::params {
   case $::osfamily {
     'AIX': {
       $config = '/etc/ntp.conf'
-      $keysfile = '/etc/ntp.keys'
+      $keys_file = '/etc/ntp.keys'
       $driftfile = '/etc/ntp.drift'
       $package_name = [ 'bos.net.tcp.client' ]
       $restrict          = [


### PR DESCRIPTION
Keys_file was incorrectly created as keysfile which is a typo.
