### PR TITLE
Tighten the dependency to > 4.0 for stdlib.

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -8,4 +8,4 @@ description 'NTP Module for Debian, Ubuntu, CentOS, RHEL, OEL, Fedora, FreeBSD, 
 project_page 'http://github.com/puppetlabs/puppetlabs-ntp'
 
 ## Add dependencies, if any:
-dependency 'puppetlabs/stdlib', '>= 0.1.6'
+dependency 'puppetlabs/stdlib', '>= 4.0.0'


### PR DESCRIPTION
We need dirname() which isn't in stdlib 3.x which ships with PE3.2.
