### PR TITLE
Packagenameempty

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -88,6 +88,14 @@ class { '::ntp':
 }
 ```
 
+###I'd like to configure and run ntp, but I don't need to install it.
+
+```puppet
+class { '::ntp':
+  package_manage => false,
+}
+```
+
 ###Looks great!  But I'd like a different template; we need to do something unique here.
 
 ```puppet
@@ -169,6 +177,10 @@ Array of trusted keys.
 ####`package_ensure`
 
 Sets the ntp package to be installed. Can be set to 'present', 'latest', or a specific version. 
+
+####`package_manage`
+
+Selects whether Puppet should manage the package.
 
 ####`package_name`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,6 +12,7 @@ class ntp (
   $keys_requestkey   = $ntp::params::keys_requestkey,
   $keys_trusted      = $ntp::params::keys_trusted,
   $package_ensure    = $ntp::params::package_ensure,
+  $package_manage    = $ntp::params::package_manage,
   $package_name      = $ntp::params::package_name,
   $panic             = $ntp::params::panic,
   $preferred_servers = $ntp::params::preferred_servers,
@@ -36,7 +37,7 @@ class ntp (
   validate_re($keys_requestkey, ['^\d+$', ''])
   validate_array($keys_trusted)
   validate_string($package_ensure)
-  validate_array($package_name)
+  if $package_manage == true { validate_array($package_name) }
   validate_bool($panic)
   validate_array($preferred_servers)
   validate_array($restrict)

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,8 +1,10 @@
 #
 class ntp::install inherits ntp {
 
-  package { $package_name:
-    ensure => $package_ensure,
+  if $package_manage == true {
+    package { 'ntp':
+      ensure => $package_ensure,
+      name   => $package_name,
+    }
   }
-
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,5 +1,6 @@
 class ntp::params {
 
+<<<<<<< HEAD
   $autoupdate        = false
   $config_template   = 'ntp/ntp.conf.erb'
   $disable_monitor   = false
@@ -98,6 +99,8 @@ class ntp::params {
       $config          = $default_config
       $driftfile       = '/var/lib/ntp/drift/ntp.drift'
       $package_name    = $default_package_name
+      $keys_file       = '/etc/ntp/keys'
+      $package_name    = [ 'ntp' ]
       $restrict        = [
         'default kod nomodify notrap nopeer noquery',
         '-6 default kod nomodify notrap nopeer noquery',
@@ -227,5 +230,9 @@ class ntp::params {
     default: {
       fail("The ${module_name} module is not supported on an ${::osfamily} based system.")
     }
+  }
+
+  if $package_manage == undef {
+    $package_manage = $default_package_manage
   }
 }

--- a/spec/acceptance/ntp_install_spec.rb
+++ b/spec/acceptance/ntp_install_spec.rb
@@ -1,8 +1,10 @@
 require 'spec_helper_acceptance'
 
+packagemanage = true
 case fact('osfamily')
 when 'FreeBSD'
   packagename = 'net/ntp'
+  packagemanage = false
 when 'Gentoo'
   packagename = 'net-misc/ntp'
 when 'Linux'
@@ -30,7 +32,7 @@ else
 end
 
 describe 'ntp::install class', :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamily')) do
-  it 'installs the package' do
+  it 'installs the package if packagemanage is true' do
     apply_manifest(%{
       class { 'ntp': }
     }, :catch_failures => true)
@@ -39,6 +41,13 @@ describe 'ntp::install class', :unless => UNSUPPORTED_PLATFORMS.include?(fact('o
   Array(packagename).each do |package|
     describe package(package) do
       it { should be_installed }
+    describe package(packagename) do
+      it do
+        if packagemanage
+          should be_installed
+        else
+        should_not be_installed
+      end
     end
   end
 end

--- a/spec/classes/ntp_spec.rb
+++ b/spec/classes/ntp_spec.rb
@@ -198,6 +198,26 @@ describe 'ntp' do
               })
             end
           end
+        describe 'should allow the package name to be overridden' do
+          let(:params) {{ :package_ensure => 'present', :package_name => ['hambaby'] }}
+          it { should contain_package('ntp').with_name('hambaby') }
+        end
+
+        describe 'should not have a package resource if package_manage is false' do
+          let(:params) {{
+            :package_manage => false,
+            :package_ensure => 'installed',
+            :package_name => ['ntp'],
+          }}
+
+          it 'when set to false' do
+            should_not contain_package('ntp').with({
+              'ensure' => 'installed',
+              'name' => 'ntp',
+            })
+          end
+        end
+      end
 
           context 'when set to false' do
             let(:params) {{


### PR DESCRIPTION
this patch add support for hosts that don't need to manage the installation of ntp.  in the current version of this module, it breaks on freebsd when using pkgng as the package provider because there is no 'net/ntp' package (there's only a port).  also, since ntp is part of base freebsd, installing it is not necessary.  instead of patching only for freebsd, this patch allows any OS to skip the install class.