### PR TITLE
Continue default behavior of package provider

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -2,8 +2,9 @@
 class ntp::install inherits ntp {
 
   package { 'ntp':
-    ensure => $package_ensure,
-    name   => $package_name,
+    ensure        => $package_ensure,
+    name          => $package_name,
+    allow_virtual => false,
   }
 
 }


### PR DESCRIPTION
Assert we are still using the default we assume of allow_virtual => false as this is now a warning and will be changed to true in future version.

Currently throws tons of errors if we don't explicitly set it to false when testing against foss
