### PR TITLE
Enable the ability to set interfaces

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -68,6 +68,17 @@ class { '::ntp':
 }
 ```
 
+###I only want to listen on specific interfaces, not on 0.0.0.0
+
+Restricting this is especially useful on Openstack nodes which may have numerous virtual interfaces.
+
+```puppet
+class { '::ntp':
+  servers  => [ 'ntp1.corp.com', 'ntp2.corp.com' ],
+  interfaces => ['127.0.0.1', '1.2.3.4']
+}
+```
+
 ###I'd like to opt out of having the service controlled; we use another tool for that.
 
 ```puppet

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,6 +15,7 @@ class ntp (
   $panic             = $ntp::params::panic,
   $preferred_servers = $ntp::params::preferred_servers,
   $restrict          = $ntp::params::restrict,
+  $interfaces        = $ntp::params::interfaces,
   $servers           = $ntp::params::servers,
   $service_enable    = $ntp::params::service_enable,
   $service_ensure    = $ntp::params::service_ensure,
@@ -37,6 +38,7 @@ class ntp (
   validate_bool($panic)
   validate_array($preferred_servers)
   validate_array($restrict)
+  validate_array($interfaces)
   validate_array($servers)
   validate_bool($service_enable)
   validate_string($service_ensure)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -13,6 +13,7 @@ class ntp::params {
   $service_ensure    = 'running'
   $service_manage    = true
   $udlc              = false
+  $interfaces        = []
 
   # On virtual machines allow large clock skews.
   $panic = str2bool($::is_virtual) ? {

--- a/spec/classes/ntp_spec.rb
+++ b/spec/classes/ntp_spec.rb
@@ -95,6 +95,27 @@ describe 'ntp' do
           }
         end
       end
+      describe 'specified interfaces' do
+        context "when set" do
+          let(:params) {{
+            :servers           => ['a', 'b', 'c', 'd'],
+            :interfaces        => ['127.0.0.1', 'a.b.c.d']
+          }}
+
+          it { should contain_file('/etc/ntp.conf').with({
+            'content' => /interface ignore wildcard\ninterface listen 127.0.0.1\ninterface listen a.b.c.d/})
+          }
+        end
+        context "when not set" do
+          let(:params) {{
+            :servers           => ['a', 'b', 'c', 'd'],
+          }}
+
+          it { should_not contain_file('/etc/ntp.conf').with({
+            'content' => /interface ignore wildcard/})
+          }
+        end
+      end
 
       describe "ntp::install on #{system}" do
         let(:params) {{ :package_ensure => 'present', :package_name => ['ntp'], }}

--- a/templates/ntp.conf.erb
+++ b/templates/ntp.conf.erb
@@ -18,6 +18,15 @@ restrict <%= restrict %>
 <% end %>
 <% end -%>
 
+<% if @interfaces != [] -%>
+# Ignore wildcard interface and only listen on the following specified
+# interfaces
+interface ignore wildcard
+<% @interfaces.flatten.each do |interface| -%>
+interface listen <%= interface %>
+<% end %>
+<% end -%>
+
 <% [@servers].flatten.each do |server| -%>
 server <%= server %><% if @preferred_servers.include?(server) -%> prefer<% end %>
 <% end -%>


### PR DESCRIPTION
Allow the settings of interfaces. If specified, the wildcard
interface will be ignored and the specified interfaces list will be
enabled for listening. This is important on Openstack control nodes
where Neutron can create dozens or even hundreds of interfaces. When new
interfaces are added it causes ntp to rescan. Specificying the interface
list prevents this from occuring.
