### PR TITLE
Add Solaris 11 support.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -221,7 +221,7 @@ The module has been tested on:
 * Gentoo
 * Arch Linux
 * FreeBSD
-* Solaris 10
+* Solaris 10, 11
 * AIX 5.3, 6.1, 7.1
 
 Testing on other platforms has been light and cannot be guaranteed. 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -136,7 +136,10 @@ class ntp::params {
       $config       = '/etc/inet/ntp.conf'
       $driftfile    = '/var/ntp/ntp.drift'
       $keys_file    = '/etc/inet/ntp.keys'
-      $package_name = [ 'SUNWntpr', 'SUNWntpu' ]
+      $package_name = $::operatingsystemrelease ? {
+        '5.10' => [ 'SUNWntpr', 'SUNWntpu' ],
+        '5.11' => [ 'service/network/ntp' ]
+      }
       $restrict     = [
         'default kod nomodify notrap nopeer noquery',
         '-6 default kod nomodify notrap nopeer noquery',

--- a/metadata.json
+++ b/metadata.json
@@ -53,7 +53,8 @@
     {
       "operatingsystem": "Solaris",
       "operatingsystemrelease": [
-        "10"
+        "10",
+        "11"
       ]
     },
     {

--- a/spec/acceptance/ntp_install_spec.rb
+++ b/spec/acceptance/ntp_install_spec.rb
@@ -15,9 +15,13 @@ when 'Linux'
 when 'AIX'
   packagename = 'bos.net.tcp.client'
 when 'Solaris'
-  packagename = ['SUNWntpr','SUNWntpu']
+  case fact('operatingsystemrelease')
+  when '5.10'
+    packagename = ['SUNWntpr','SUNWntpu']
+  when '5.11'
+    packagename = 'service/network/ntp'
+  end
 else
-  packagename = 'ntp'
 end
 
 describe 'ntp::install class', :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamily')) do

--- a/spec/acceptance/ntp_parameters_spec.rb
+++ b/spec/acceptance/ntp_parameters_spec.rb
@@ -15,7 +15,12 @@ when 'Linux'
 when 'AIX'
   packagename = 'bos.net.tcp.client'
 when 'Solaris'
-  packagename = ['SUNWntpr','SUNWntpu']
+  case fact('operatingsystemrelease')
+  when '5.10'
+    packagename = ['SUNWntpr','SUNWntpu']
+  when '5.11'
+    packagename = 'service/network/ntp'
+  end
 else
   packagename = 'ntp'
 end

--- a/spec/classes/ntp_spec.rb
+++ b/spec/classes/ntp_spec.rb
@@ -249,8 +249,18 @@ describe 'ntp' do
         end
       end
 
-      describe "on osfamily Solaris" do
-        let(:facts) {{ :osfamily => 'Solaris' }}
+      describe "on osfamily Solaris and operatingsystemrelease 5.10" do
+        let(:facts) {{ :osfamily => 'Solaris', :operatingsystemrelease => '5.10' }}
+
+        it 'uses the NTP pool servers by default' do
+          should contain_file('/etc/inet/ntp.conf').with({
+            'content' => /server \d.pool.ntp.org/,
+          })
+        end
+      end
+
+      describe "on osfamily Solaris and operatingsystemrelease 5.11" do
+        let(:facts) {{ :osfamily => 'Solaris', :operatingsystemrelease => '5.11' }}
 
         it 'uses the NTP pool servers by default' do
           should contain_file('/etc/inet/ntp.conf').with({


### PR DESCRIPTION
  This commit is a simple change to Class['ntp::params'] which adds a
  selector to the default Solaris data so that the proper package name
  is managed on Solaris 11.

  With out this small change Solaris 11 hosts will attempt to improperly
  install package names following the old Solaris 10 standard.
