### PR TITLE
Various test setup fixes

### DIFF
--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -6,10 +6,15 @@ unless ENV['RS_PROVISION'] == 'no' or ENV['BEAKER_provision'] == 'no'
   if hosts.first.is_pe?
     install_pe
   else
-    install_puppet
+    install_puppet({ :version        => '3.6.2',
+                     :facter_version => '2.1.0',
+                     :hiera_version  => '1.3.4',
+                     :default_action => 'gem_install' })
+    on host, "/bin/echo '' > #{default['hieraconf']}"
   end
   hosts.each do |host|
-    on hosts, "mkdir -p #{host['distmoduledir']}"
+    on host, "mkdir -p #{host['distmoduledir']}"
+    on host, 'puppet module install puppetlabs-stdlib', :acceptable_exit_codes => [0,1]
   end
 end
 
@@ -22,11 +27,7 @@ RSpec.configure do |c|
 
   # Configure all nodes in nodeset
   c.before :suite do
-    # Install module and dependencies
+    # Install module
     puppet_module_install(:source => proj_root, :module_name => 'ntp')
-    hosts.each do |host|
-      shell("/bin/touch #{default['puppetpath']}/hiera.yaml")
-      shell('puppet module install puppetlabs-stdlib', :acceptable_exit_codes => [0,1])
-    end
   end
 end


### PR DESCRIPTION
Specifically updates our usage of `install_puppet()` to a) specify
version numbers (allowing installation on platforms that have native
packages but no native dependency resolution) and b) default to
installing from gem if no other installation candidate exists for the
platform.

We also update the creation of a hiera.yaml file to use `echo '' >`
instead of `touch` because touch puts in a newline that is encoded in
such a way on Debian 7 as to be unparsable by Ruby's YAML parser.

And finally we ensure we are setting these and other prerequisites
(stdlib) on all hosts, not just the default.
