### PR TITLE
fix up mistake in setup

### DIFF
--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -10,7 +10,7 @@ unless ENV['RS_PROVISION'] == 'no' or ENV['BEAKER_provision'] == 'no'
                      :facter_version => '2.1.0',
                      :hiera_version  => '1.3.4',
                      :default_action => 'gem_install' })
-    on host, "/bin/echo '' > #{default['hieraconf']}"
+    hosts.each {|h| on h, "/bin/echo '' > #{h['hieraconf']}" }
   end
   hosts.each do |host|
     on host, "mkdir -p #{host['distmoduledir']}"


### PR DESCRIPTION
The previous code was written to be inside a hosts.each {} block, but wasn't. Also, apparently serverspec also defines a `host` method(?) that causes a very odd error message to come from serverspec instead of where it should...
