### PR TITLE
Fix issue with different solaris osrelease

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -137,8 +137,8 @@ class ntp::params {
       $driftfile    = '/var/ntp/ntp.drift'
       $keys_file    = '/etc/inet/ntp.keys'
       $package_name = $::operatingsystemrelease ? {
-        '5.10' => [ 'SUNWntpr', 'SUNWntpu' ],
-        '5.11' => [ 'service/network/ntp' ]
+        /^(5\.10|10|10_u\d+)$/ => [ 'SUNWntpr', 'SUNWntpu' ],
+        /^(5\.11|11|11\.\d+)$/ => [ 'service/network/ntp' ]
       }
       $restrict     = [
         'default kod nomodify notrap nopeer noquery',


### PR DESCRIPTION
Facter operating system release should be returning 10, 10_u11, 11,
or 11.1. This fixes the regex to handle all cases.
