### PR TITLE
Fix acceptance tests for ntp iburst addition

### DIFF
--- a/spec/acceptance/nodesets/ubuntu-server-14042-x64.yml
+++ b/spec/acceptance/nodesets/ubuntu-server-14042-x64.yml
@@ -1,0 +1,16 @@
+HOSTS:
+  ubuntu1404:
+    roles:
+      - agent
+    platform: ubuntu-14.04-amd64
+    template: ubuntu-1404-x86_64
+    hypervisor: vcloud
+CONFIG:
+  type: foss
+  keyfile: ~/.ssh/id_rsa-acceptance
+  nfs_server: none
+  consoleport: 443
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vcloud.delivery.puppetlabs.net/

--- a/spec/acceptance/preferred_servers_spec.rb
+++ b/spec/acceptance/preferred_servers_spec.rb
@@ -18,7 +18,7 @@ describe 'preferred servers', :unless => UNSUPPORTED_PLATFORMS.include?(fact('os
     it { should be_file }
     it { should contain 'server a' }
     it { should contain 'server b' }
-    it { should contain 'server c prefer' }
-    it { should contain 'server d prefer' }
+    its(:content) { should match /server c (iburst\s|)prefer/ }
+    its(:content) { should match /server d (iburst\s|)prefer/ }
   end
 end


### PR DESCRIPTION
Additional logic to use regex and not care when the system default is iburst, this is due to refactor of iburst as an optional parameter that has osfamily defaults
