### PR TITLE
Synchronize with modulesync

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -1,1 +1,3 @@
 ---
+spec/spec_helper.rb:
+  unmanaged: true


### PR DESCRIPTION
Avoids removing additions to spec_helper.rb since the last sync by dropping management for spec_helper.rb.
