### PR TITLE
Remove dependency on stdlib4

### DIFF
--- a/lib/puppet/parser/functions/ntp_dirname.rb
+++ b/lib/puppet/parser/functions/ntp_dirname.rb
@@ -1,0 +1,15 @@
+module Puppet::Parser::Functions
+  newfunction(:ntp_dirname, :type => :rvalue, :doc => <<-EOS
+    Returns the dirname of a path.
+    EOS
+  ) do |arguments|
+
+    raise(Puppet::ParseError, "ntp_dirname(): Wrong number of arguments " +
+      "given (#{arguments.size} for 1)") if arguments.size < 1
+
+    path = arguments[0]
+    return File.dirname(path)
+  end
+end
+
+# vim: set ts=2 sw=2 et :

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -2,7 +2,7 @@
 class ntp::config inherits ntp {
 
   if $keys_enable {
-    $directory = dirname($keys_file)
+    $directory = ntp_dirname($keys_file)
     file { $directory:
       ensure  => directory,
       owner   => 0,

--- a/metadata.json
+++ b/metadata.json
@@ -6,7 +6,7 @@
   "license": "Apache Version 2.0",
   "source": "git://github.com/puppetlabs/puppetlabs-ntp",
   "project_page": "http://github.com/puppetlabs/puppetlabs-ntp",
-  "issues_url": "https://github.com/puppetlabs/puppetlabs-ntp/issues",
+  "issues_url": "https://tickets.puppetlabs.com/browse/MODULES",
   "operatingsystem_support": [
     {
       "operatingsystem": "RedHat",
@@ -70,7 +70,7 @@
   "requirements": [
     {
       "name": "pe",
-      "version_requirement": "3.3.x"
+      "version_requirement": "3.x"
     },
     {
       "name": "puppet",
@@ -81,7 +81,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.0.0"
+      "version_requirement": ">= 3.2.0 < 5.0.0"
     }
   ]
 }


### PR DESCRIPTION
This removes the backwards incompatible change between 3.0.x and 3.1.x.
