### PR TITLE
Notify the service when changing the config

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -18,6 +18,7 @@ class ntp::config inherits ntp {
     group   => 0,
     mode    => '0644',
     content => template($config_template),
+    notify  => Class['ntp::service'],
   }
 
 }

--- a/spec/classes/ntp_spec.rb
+++ b/spec/classes/ntp_spec.rb
@@ -247,6 +247,7 @@ describe 'ntp' do
         it 'uses the NTP pool servers by default' do
           should contain_file('/etc/ntp.conf').with({
             'content' => /server \d.gentoo.pool.ntp.org/,
+            'notify'  => 'Class[Ntp::Service]',
           })
         end
       end
@@ -259,6 +260,7 @@ describe 'ntp' do
         it 'uses the NTP pool servers by default' do
           should contain_file('/etc/ntp.conf').with({
             'content' => /server \d.gentoo.pool.ntp.org/,
+            'notify'  => 'Class[Ntp::Service]',
           })
         end
       end
@@ -271,6 +273,7 @@ describe 'ntp' do
         it 'uses the debian ntp servers by default' do
           should contain_file('/etc/ntp.conf').with({
             'content' => /server \d.debian.pool.ntp.org iburst\n/,
+            'notify'  => 'Class[Ntp::Service]',
           })
         end
       end
@@ -283,6 +286,7 @@ describe 'ntp' do
         it 'uses the redhat ntp servers by default' do
           should contain_file('/etc/ntp.conf').with({
             'content' => /server \d.centos.pool.ntp.org/,
+            'notify'  => 'Class[Ntp::Service]',
           })
         end
       end
@@ -295,6 +299,7 @@ describe 'ntp' do
         it 'uses the opensuse ntp servers by default' do
           should contain_file('/etc/ntp.conf').with({
             'content' => /server \d.opensuse.pool.ntp.org/,
+            'notify'  => 'Class[Ntp::Service]',
           })
         end
       end
@@ -307,6 +312,7 @@ describe 'ntp' do
         it 'uses the freebsd ntp servers by default' do
           should contain_file('/etc/ntp.conf').with({
             'content' => /server \d.freebsd.pool.ntp.org maxpoll 9 iburst/,
+            'notify'  => 'Class[Ntp::Service]',
           })
         end
       end
@@ -319,6 +325,7 @@ describe 'ntp' do
         it 'uses the NTP pool servers by default' do
           should contain_file('/etc/ntp.conf').with({
             'content' => /server \d.pool.ntp.org/,
+            'notify'  => 'Class[Ntp::Service]',
           })
         end
       end
@@ -331,6 +338,7 @@ describe 'ntp' do
         it 'uses the NTP pool servers by default' do
           should contain_file('/etc/inet/ntp.conf').with({
             'content' => /server \d.pool.ntp.org/,
+            'notify'  => 'Class[Ntp::Service]',
           })
         end
       end
@@ -343,6 +351,7 @@ describe 'ntp' do
         it 'uses the NTP pool servers by default' do
           should contain_file('/etc/inet/ntp.conf').with({
             'content' => /server \d.pool.ntp.org/,
+            'notify'  => 'Class[Ntp::Service]',
           })
         end
       end


### PR DESCRIPTION
When changing NTP configuration (by using ntp::config), we need to
restart the NTP service. Otherwise, it's not sure that time will be
synchronized with clock servers.

This patchs adds a "notify" to the NTP configuration file and add spec
tests.
