### PR TITLE
Use puppet('module install puppetlabs-stdlib')

### DIFF
--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -14,7 +14,7 @@ unless ENV['RS_PROVISION'] == 'no' or ENV['BEAKER_provision'] == 'no'
       on host, "/bin/echo '' > #{host['hieraconf']}"
     end
     on host, "mkdir -p #{host['distmoduledir']}"
-    puppet_module_install_on(host, :module_name => 'puppetlabs-stdlib')
+    on host, puppet('module install puppetlabs-stdlib'), { :acceptable_exit_codes => [0,1] }
   end
 end
 


### PR DESCRIPTION
We need to be able to pass a block to this since the stdlib install
fails sometime on PE (which is ok, since it's included)
