### PR TITLE
Remove recursion, this can expose sensitive information.

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -8,7 +8,6 @@ class ntp::config inherits ntp {
       owner   => 0,
       group   => 0,
       mode    => '0755',
-      recurse => true,
     }
   }
 


### PR DESCRIPTION
Changing to mode 0755 and recursing through /etc/ntp/ can potentially expose sensitive information like /etc/ntp/crypto/pw file which holds the private key password if you are using public keys with NTP. Some folks may consider exposing /etc/ntp/keys to be sensitive as well.

-Erinn
