### PR TITLE
Fixing logfile parameter.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -166,6 +166,10 @@ Which of the keys is the request key.
 
 Array of trusted keys.
 
+#### `logfile`
+
+Absolute path of the alternate log file. If unspecified, ntp uses syslog by default. 
+
 ####`package_ensure`
 
 Sets the ntp package to be installed. Can be set to 'present', 'latest', or a specific version. 

--- a/spec/classes/ntp_spec.rb
+++ b/spec/classes/ntp_spec.rb
@@ -221,7 +221,7 @@ describe 'ntp' do
 
             it 'should contain logfile setting' do
               should contain_file('/etc/ntp.conf').with({
-              'content' => /^logfile = \/var\/log\/foobar\.log\n/,
+              'content' => /^logfile \/var\/log\/foobar\.log\n/,
               })
             end
           end
@@ -233,7 +233,7 @@ describe 'ntp' do
 
             it 'should not contain a logfile line' do
               should_not contain_file('/etc/ntp.conf').with({
-                'content' => /logfile =/,
+                'content' => /logfile /,
               })
             end
           end

--- a/templates/ntp.conf.erb
+++ b/templates/ntp.conf.erb
@@ -44,7 +44,7 @@ driftfile <%= @driftfile %>
 
 <% unless @logfile.nil? -%>
 # Logfile
-logfile = <%= @logfile %>
+logfile <%= @logfile %>
 <% end -%>
 
 <% if @keys_enable -%>


### PR DESCRIPTION
Removing equal sign as delimiter in ntp.conf for the logfile parameter.
Adding documentation of logfile parameter in README.