### PR TITLE
(MODULES-1479) Add package_manage parameter

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -88,6 +88,14 @@ class { '::ntp':
 }
 ```
 
+###I'd like to configure and run ntp, but I don't need to install it.
+
+```puppet
+class { '::ntp':
+  package_manage => false,
+}
+```
+
 ###Looks great!  But I'd like a different template; we need to do something unique here.
 
 ```puppet
@@ -168,7 +176,11 @@ Array of trusted keys.
 
 ####`package_ensure`
 
-Sets the ntp package to be installed. Can be set to 'present', 'latest', or a specific version. 
+Sets the ntp package to be installed. Can be set to 'present', 'latest', or a specific version.
+
+####`package_manage`
+
+Determines whether to manage the ntp package. Defaults to true.
 
 ####`package_name`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,6 +12,7 @@ class ntp (
   $keys_requestkey   = $ntp::params::keys_requestkey,
   $keys_trusted      = $ntp::params::keys_trusted,
   $package_ensure    = $ntp::params::package_ensure,
+  $package_manage    = $ntp::params::package_manage,
   $package_name      = $ntp::params::package_name,
   $panic             = $ntp::params::panic,
   $preferred_servers = $ntp::params::preferred_servers,
@@ -36,6 +37,7 @@ class ntp (
   validate_re($keys_requestkey, ['^\d+$', ''])
   validate_array($keys_trusted)
   validate_string($package_ensure)
+  validate_bool($package_manage)
   validate_array($package_name)
   validate_bool($panic)
   validate_array($preferred_servers)

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,8 +1,12 @@
 #
 class ntp::install inherits ntp {
 
-  package { $package_name:
-    ensure => $package_ensure,
+  if $package_manage {
+
+    package { $package_name:
+      ensure => $package_ensure,
+    }
+
   }
 
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -28,6 +28,11 @@ class ntp::params {
   $default_package_name = ['ntp']
   $default_service_name = 'ntpd'
 
+  $package_manage = $::osfamily ? {
+    'FreeBSD' => false,
+    default   => true,
+  }
+
   case $::osfamily {
     'AIX': {
       $config        = $default_config

--- a/spec/acceptance/ntp_install_spec.rb
+++ b/spec/acceptance/ntp_install_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper_acceptance'
 
+packagemanage = true
+
 case fact('osfamily')
 when 'FreeBSD'
   packagename = 'net/ntp'
@@ -30,9 +32,9 @@ else
 end
 
 describe 'ntp::install class', :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamily')) do
-  it 'installs the package' do
+  it 'installs the package when package_manage is set to true' do
     apply_manifest(%{
-      class { 'ntp': }
+      class { 'ntp': package_manage => true }
     }, :catch_failures => true)
   end
 
@@ -40,5 +42,11 @@ describe 'ntp::install class', :unless => UNSUPPORTED_PLATFORMS.include?(fact('o
     describe package(package) do
       it { should be_installed }
     end
+  end
+
+  it 'does not install the package when package_manage is set to false' do
+    apply_manifest(%{
+      class { 'ntp': package_manage => false }
+    }, :catch_changes => true)
   end
 end

--- a/spec/classes/ntp_spec.rb
+++ b/spec/classes/ntp_spec.rb
@@ -128,20 +128,25 @@ describe 'ntp' do
         end
 
         describe "ntp::install on #{system}" do
-          let(:params) {{ :package_ensure => 'present', :package_name => ['ntp'], }}
+          let(:params) {{ :package_ensure => 'present', :package_name => ['ntp'], :package_manage => true, }}
 
           it { should contain_package('ntp').with(
             :ensure => 'present'
           )}
 
           describe 'should allow package ensure to be overridden' do
-            let(:params) {{ :package_ensure => 'latest', :package_name => ['ntp'] }}
+            let(:params) {{ :package_ensure => 'latest', :package_name => ['ntp'], :package_manage => true, }}
             it { should contain_package('ntp').with_ensure('latest') }
           end
 
           describe 'should allow the package name to be overridden' do
-            let(:params) {{ :package_ensure => 'present', :package_name => ['hambaby'] }}
+            let(:params) {{ :package_ensure => 'present', :package_name => ['hambaby'], :package_manage => true, }}
             it { should contain_package('hambaby') }
+          end
+
+          describe 'should allow the package to be unmanaged' do
+            let(:params) {{ :package_manage => false, :package_name => ['ntp'], }}
+            it { should_not contain_package('ntp') }
           end
         end
 


### PR DESCRIPTION
As described in MODULES-1479, certain FreeBSD base installations already include the base version of ntp and FreeBSD users don't want the ntp module to manage the package on these systems.

This PR uses ideas from PR #154 , which for whatever reason has stalled.
@sethlyons - Is this missing anything?

