### PR TITLE
extend Readme for a simple client

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -67,6 +67,22 @@ class { '::ntp':
 }
 ```
 
+###I just want to install a client that can't be queried
+
+```puppet
+class { '::ntp':
+  servers   => ['ntp1.corp.com', 'ntp2.corp.com'],
+  restrict  => [
+    'default ignore',
+    '-6 default ignore',
+    '127.0.0.1',
+    '-6 ::1',
+    'ntp1.corp.com nomodify notrap nopeer noquery',
+    'ntp1.corp.com nomodify notrap nopeer noquery'
+  ],
+}
+```
+
 ###I only want to listen on specific interfaces, not on 0.0.0.0
 
 Restricting this is especially useful on Openstack nodes which may have numerous virtual interfaces.


### PR DESCRIPTION
these restrictions are needed if you want to install an ntpd that only acts as a client

1) disable global acces
2) allow localhost completly (usefull for just in time config changes via cli)
3) allow minimal access to the source servers

everything for IPv4 and IPv6

settings are based on http://support.ntp.org/bin/view/Support/AccessRestrictions

more and more reflectd NTP attackes are commen on the internet, so it is pretty dangerous to install a simple client without these settings. I guess they could be usefull for other people.