### PR TITLE
fix `is_virtual` detection issue

### DIFF
--- a/templates/ntp.conf.erb
+++ b/templates/ntp.conf.erb
@@ -31,7 +31,7 @@ interface listen <%= interface %>
 server <%= server %><% if @iburst_enable == true -%> iburst<% end %><% if @preferred_servers.include?(server) -%> prefer<% end %>
 <% end -%>
 
-<% if scope.lookupvar('::is_virtual') == "false" or @udlc -%>
+<% if @is_virtual == "true" or @udlc -%>
 # Undisciplined Local Clock. This is a fake driver intended for backup
 # and when no outside source of synchronized time is available. 
 server	127.127.1.0 


### PR DESCRIPTION
adjust the expression to ensure `127.127.1.0` is set only if target is running
under virtual environment or `udlc` is set.

if `server` pointed to `127.127.1.0` without `preferred_servers` settings, it
would try to sync with itself but not to the `server`.