### PR TITLE
Broadcast and auth

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -146,6 +146,10 @@ The following parameters are available in the ntp module:
 **Deprecated:** This parameter determined whether the ntp module should be
 automatically updated to the latest version available.  Replaced by `package_ensure`.
 
+####`broadcastclient`
+
+Enable reception of broadcast server messages to any local interface.
+
 ####`config`
 
 Sets the file that ntp configuration is written into.
@@ -153,6 +157,11 @@ Sets the file that ntp configuration is written into.
 ####`config_template`
 
 Determines which template Puppet should use for the ntp configuration.
+
+####`disable_auth`
+
+Do  not  require cryptographic authentication for broadcast client, multicast 
+client and symmetric passive associations.
 
 ####`disable_monitor`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,7 +1,9 @@
 class ntp (
   $autoupdate        = $ntp::params::autoupdate,
+  $broadcastclient   = $ntp::params::broadcastclient,
   $config            = $ntp::params::config,
   $config_template   = $ntp::params::config_template,
+  $disable_auth      = $ntp::params::disable_auth,
   $disable_monitor   = $ntp::params::disable_monitor,
   $driftfile         = $ntp::params::driftfile,
   $logfile           = $ntp::params::logfile,
@@ -26,8 +28,10 @@ class ntp (
   $udlc              = $ntp::params::udlc
 ) inherits ntp::params {
 
+  validate_bool($broadcastclient)
   validate_absolute_path($config)
   validate_string($config_template)
+  validate_bool($disable_auth)
   validate_bool($disable_monitor)
   validate_absolute_path($driftfile)
   if $logfile { validate_absolute_path($logfile) }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -15,6 +15,8 @@ class ntp::params {
   $service_manage    = true
   $udlc              = false
   $interfaces        = []
+  $disable_auth      = false
+  $broadcastclient   = false
 
 # On virtual machines allow large clock skews.
   $panic = str2bool($::is_virtual) ? {

--- a/spec/classes/ntp_spec.rb
+++ b/spec/classes/ntp_spec.rb
@@ -126,6 +126,54 @@ describe 'ntp' do
             }
           end
         end
+        describe 'with parameter disable_auth' do
+          context 'when set to true' do
+            let(:params) {{
+              :disable_auth => true,
+            }}
+
+            it 'should contain disable auth setting' do
+              should contain_file('/etc/ntp.conf').with({
+              'content' => /^disable auth\n/,
+              })
+            end
+          end
+          context 'when set to false' do
+            let(:params) {{
+              :disable_auth => false,
+            }}
+
+            it 'should not contain disable auth setting' do
+              should_not contain_file('/etc/ntp.conf').with({
+              'content' => /^disable auth\n/,
+              })
+            end
+          end
+        end
+        describe 'with parameter broadcastclient' do
+          context 'when set to true' do
+            let(:params) {{
+              :broadcastclient => true,
+            }}
+
+            it 'should contain broadcastclient setting' do
+              should contain_file('/etc/ntp.conf').with({
+              'content' => /^broadcastclient\n/,
+              })
+            end
+          end
+          context 'when set to false' do
+            let(:params) {{
+              :broadcastclient => false,
+            }}
+
+            it 'should not contain broadcastclient setting' do
+              should_not contain_file('/etc/ntp.conf').with({
+              'content' => /^broadcastclient\n/,
+              })
+            end
+          end
+        end
 
         describe "ntp::install on #{system}" do
           let(:params) {{ :package_ensure => 'present', :package_name => ['ntp'], :package_manage => true, }}

--- a/templates/ntp.conf.erb
+++ b/templates/ntp.conf.erb
@@ -9,6 +9,9 @@ tinker panic 0
 <% if @disable_monitor == true -%>
 disable monitor
 <% end -%>
+<% if @disable_auth == true -%>
+disable auth
+<% end -%>
 
 <% if @restrict != [] -%>
 # Permit time synchronization with our time source, but do not
@@ -25,6 +28,10 @@ interface ignore wildcard
 <% @interfaces.flatten.each do |interface| -%>
 interface listen <%= interface %>
 <% end -%>
+<% end -%>
+
+<% if @broadcastclient == true -%>
+broadcastclient
 <% end -%>
 
 <% [@servers].flatten.each do |server| -%>


### PR DESCRIPTION
Hi,

this patch enables two configuration options in ntp.conf : the broadcast mode (the simple way) and the disabling of authentication.

Would you mind envisaging to merge those changes ?