### PR TITLE
Fix PR #235 and make udlc configurable

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -255,7 +255,7 @@ Tells Puppet what NTP service to manage. Valid options: string. Default value: v
 
 ####`udlc`
 
-Specifies whether to enable specialized configuration options for an undisciplined local clock, regardless of its status as a virtual machine. Valid options: 'true' or 'false'. Default value: 'false'
+Specifies whether to configure ntp to use the undisciplined local clock as a time source, regardless of the node's status as a virtual machine. Valid options: 'true' or 'false'. Default value: 'false' for VMs and 'true' otherwise.
 
 ##Limitations
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -13,7 +13,6 @@ class ntp::params {
   $service_enable    = true
   $service_ensure    = 'running'
   $service_manage    = true
-  $udlc              = false
   $interfaces        = []
   $disable_auth      = false
   $broadcastclient   = false
@@ -21,6 +20,15 @@ class ntp::params {
 # On virtual machines allow large clock skews.
   $panic = str2bool($::is_virtual) ? {
     true    => false,
+    default => true,
+  }
+
+  # On virtual systems, disable the use of the undisciplined local clock to
+  # avoid ntp falling back to the local clock in preference over ntp servers.
+  # TODO Change this to str2bool($::is_virtual) when stdlib dependency is >= 4
+  # NOTE The "x${var}" is just to avoid lint quoted variable warning.
+  $udlc = "x${::is_virtual}" ? {
+    'xtrue' => false,
     default => true,
   }
 

--- a/templates/ntp.conf.erb
+++ b/templates/ntp.conf.erb
@@ -38,11 +38,11 @@ broadcastclient
 server <%= server %><% if @iburst_enable == true -%> iburst<% end %><% if @preferred_servers.include?(server) -%> prefer<% end %>
 <% end -%>
 
-<% if @is_virtual == "true" or @udlc -%>
+<% if @udlc -%>
 # Undisciplined Local Clock. This is a fake driver intended for backup
-# and when no outside source of synchronized time is available. 
-server	127.127.1.0 
-fudge	127.127.1.0 stratum 10
+# and when no outside source of synchronized time is available.
+server   127.127.1.0
+fudge    127.127.1.0 stratum 10
 restrict 127.127.1.0
 <% end -%>
 


### PR DESCRIPTION
The UDLC should really only be used on machines with accurate clocks, and
this logic was reversed incorrectly.

This PR also allows the udlc setting to be overridden, whereas before it
was not.