### PR TITLE
(MODULES-1796) Fix stdlib 3.2.0 compatibility

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -18,9 +18,11 @@ class ntp::params {
   $disable_auth      = false
   $broadcastclient   = false
 
-# On virtual machines allow large clock skews.
-  $panic = str2bool($::is_virtual) ? {
-    true    => false,
+  # On virtual machines allow large clock skews.
+  # TODO Change this to str2bool($::is_virtual) when stdlib dependency is >= 4.0.0
+  # NOTE The "x${var}" is just to avoid lint quoted variable warning.
+  $panic = "x${::is_virtual}" ? {
+    'xtrue' => false,
     default => true,
   }
 


### PR DESCRIPTION
Stdlib 4.0.0 allows str2bool to take a bool as an argument;
unfortunately ntp still claims to work with stdlib >= 3.2.0