### PR TITLE
No Undisciplined Local Clock by default

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -259,7 +259,7 @@ Tells Puppet what NTP service to manage. Valid options: string. Default value: v
 
 ####`udlc`
 
-Specifies whether to configure ntp to use the undisciplined local clock as a time source, regardless of the node's status as a virtual machine. Valid options: 'true' or 'false'. Default value: 'false' for VMs and 'true' otherwise.
+Specifies whether to configure ntp to use the undisciplined local clock as a time source. Valid options: 'true' or 'false'. Default value: 'false'
 
 ##Limitations
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -13,6 +13,7 @@ class ntp::params {
   $service_enable    = true
   $service_ensure    = 'running'
   $service_manage    = true
+  $udlc              = false
   $interfaces        = []
   $disable_auth      = false
   $broadcastclient   = false
@@ -24,15 +25,6 @@ class ntp::params {
   # TODO Change this to str2bool($::is_virtual) when stdlib dependency is >= 4.0.0
   # NOTE The "x${var}" is just to avoid lint quoted variable warning.
   $panic = "x${::is_virtual}" ? {
-    'xtrue' => false,
-    default => true,
-  }
-
-  # On virtual systems, disable the use of the undisciplined local clock to
-  # avoid ntp falling back to the local clock in preference over ntp servers.
-  # TODO Change this to str2bool($::is_virtual) when stdlib dependency is >= 4
-  # NOTE The "x${var}" is just to avoid lint quoted variable warning.
-  $udlc = "x${::is_virtual}" ? {
     'xtrue' => false,
     default => true,
   }


### PR DESCRIPTION
Do not enable UDLC by default on baremetal (non-virtual) systems.
Baremetal systems might not serve as time-source at all.
UDLC is not a back-up for leaf-nodes (ntp client only)!

See http://support.ntp.org/bin/view/Support/UndisciplinedLocalClock