### PR TITLE
Bump stdlib to 4.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## 2015-xx-xx - Supported Release 4.0.0
+### Summary
+This release drops puppet 2.7 support and older stdlib support.
+
+#### Backwards-incompatible changes
+- UDLC (Undisciplined local clock) is now no longer enabled by default on anything (previous was enabled on non-virtual).
+- Puppet 2.7 no longer supported
+- puppetlabs-stdlib less than 4.5.0 no longer supported
+- TODO: The `keys_file` parent directory is no longer managed by puppet
+
+#### Features
+- TODO
+
+#### Bugfixes
+- TODO
+
 ##2014-11-04 - Supported Release 3.3.0
 ###Summary
 

--- a/metadata.json
+++ b/metadata.json
@@ -81,7 +81,7 @@
   "requirements": [
     {
       "name": "pe",
-      "version_requirement": "3.x"
+      "version_requirement": ">= 3.7.0 < 4.0.0"
     },
     {
       "name": "puppet",
@@ -90,6 +90,6 @@
   ],
   "description": "NTP Module for Debian, Ubuntu, CentOS, RHEL, OEL, Fedora, FreeBSD, ArchLinux and Gentoo.",
   "dependencies": [
-    {"name":"puppetlabs/stdlib","version_requirement":">= 3.2.0 < 5.0.0"}
+    {"name":"puppetlabs/stdlib","version_requirement":">= 4.5.0 < 5.0.0"}
   ]
 }


### PR DESCRIPTION
PE 3.7.0 is free of vendored modules chains, so we like that release.
And we like newer stdlib.