### PR TITLE
Add Solaris 10 Support

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -167,16 +167,22 @@ class ntp::params {
       $config        = '/etc/inet/ntp.conf'
       $driftfile     = '/var/ntp/ntp.drift'
       $keys_file     = '/etc/inet/ntp.keys'
-      $package_name  = $::operatingsystemrelease ? {
-        /^(5\.10|10|10_u\d+)$/ => [ 'SUNWntpr', 'SUNWntpu' ],
-        /^(5\.11|11|11\.\d+)$/ => [ 'service/network/ntp' ]
+      if $::operatingsystemrelease =~ /^(5\.10|10|10_u\d+)$/
+      {
+        $package_name = [ 'SUNWntpr', 'SUNWntpu' ]
+        $restrict     = [
+          'default nomodify notrap nopeer noquery',
+          '127.0.0.1',
+        ]
+      } else {
+        $package_name = [ 'service/network/ntp' ]
+        $restrict     = [
+          'default kod nomodify notrap nopeer noquery',
+          '-6 default kod nomodify notrap nopeer noquery',
+          '127.0.0.1',
+          '-6 ::1',
+        ]
       }
-      $restrict      = [
-        'default kod nomodify notrap nopeer noquery',
-        '-6 default kod nomodify notrap nopeer noquery',
-        '127.0.0.1',
-        '-6 ::1',
-      ]
       $service_name  = 'network/ntp'
       $iburst_enable = false
       $servers       = [


### PR DESCRIPTION
Hi
the default ntpd on Solaris 10 is xntpd like on AIX. So we should use an other default case for Solaris 10.

ntpd, which supports all the restricts, is installed with Solaris 10u9. The service name for this new ntpd is "network/ntp4"

I think this commit should be helpful for a better Solaris 10 Support

greetings
Reamer
