### PR TITLE
(MODULES-1941) Fix: SLES12 Support

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -107,7 +107,7 @@ class ntp::params {
       $maxpoll         = undef
     }
     'Suse': {
-      if $::operatingsystem == 'SLES' and $::operatingsystemmajrelease == '12'
+      if $::operatingsystem == 'SLES' and $::operatingsystemrelease =~ /^12\.\d/
       {
         $service_name  = 'ntpd'
         $keys_file     = '/etc/ntp.keys'

--- a/spec/acceptance/ntp_install_spec.rb
+++ b/spec/acceptance/ntp_install_spec.rb
@@ -22,7 +22,7 @@ when 'Solaris'
     packagename = 'service/network/ntp'
   end
 else
-  if fact('operatingsystem') == 'SLES' and fact('operatingsystemmajrelease') == '12'
+  if fact('operatingsystem') == 'SLES' and fact('operatingsystemrelease') =~ /^12\.\d/
     servicename = 'ntpd'
   else
     servicename = 'ntp'

--- a/spec/acceptance/ntp_parameters_spec.rb
+++ b/spec/acceptance/ntp_parameters_spec.rb
@@ -22,7 +22,7 @@ when 'Solaris'
     packagename = 'service/network/ntp'
   end
 else
-  if fact('operatingsystem') == 'SLES' and fact('operatingsystemmajrelease') == '12'
+  if fact('operatingsystem') == 'SLES' and fact('operatingsystemrelease') =~ /^12\.\d/
     servicename = 'ntpd'
   else
     servicename = 'ntp'

--- a/spec/acceptance/ntp_service_spec.rb
+++ b/spec/acceptance/ntp_service_spec.rb
@@ -9,7 +9,7 @@ case fact('osfamily')
   when 'AIX'
     servicename = 'xntpd'
   else
-    if fact('operatingsystem') == 'SLES' and fact('operatingsystemmajrelease') == '12'
+    if fact('operatingsystem') == 'SLES' and fact('operatingsystemrelease') =~ /^12\.\d/
       servicename = 'ntpd'
     else
       servicename = 'ntp'
@@ -17,7 +17,7 @@ case fact('osfamily')
 end
 shared_examples 'running' do
   describe service(servicename) do
-    if !(fact('operatingsystem') == 'SLES' && fact('operatingsystemmajrelease') == '12')
+    if !(fact('operatingsystem') == 'SLES' && fact('operatingsystemrelease') =~ /^12\.\d/)
       it { should be_running }
       it { should be_enabled }
     else
@@ -71,7 +71,7 @@ describe 'service is unmanaged' do
   end
 
   describe service(servicename) do
-    if !(fact('operatingsystem') == 'SLES' && fact('operatingsystemmajrelease') == '12')
+    if !(fact('operatingsystem') == 'SLES' && fact('operatingsystemrelease') =~ /^12\.\d/)
       it { should be_running }
       it { should be_enabled }
     else


### PR DESCRIPTION
Hi,

this fix is related to ticket MODULES-1941.
The fact "operatingsystemmajrelease" is missing in the official puppet-agent/facter supplied by SuSE. 
Hope you like this simple fix.


Thanks a lot.
Best Regards,

Gerrit.