### PR TITLE
fixes debian-based flakiness in acceptance tests

### DIFF
--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -24,6 +24,11 @@ unless ENV['RS_PROVISION'] == 'no' or ENV['BEAKER_provision'] == 'no'
     else
       on host, puppet('module install puppetlabs-stdlib'), {:acceptable_exit_codes => [0, 1]}
     end
+
+    if fact('osfamily') == 'Debian'
+      shell('[[ -f /etc/dhcp/dhclient-exit-hooks.d/ntp ]] && rm /etc/dhcp/dhcp-exit-hooks.d/ntp', { :acceptable_exit_codes => [0, 1] })
+      shell('[[ -f /etc/dhcp3/dhclient-exit-hooks.d/ntp ]] && rm /etc/dhcp3/dhcp-exit-hooks.d/ntp', { :acceptable_exit_codes => [0, 1] })
+    end
   end
 end
 


### PR DESCRIPTION
Unpredictable acceptance test failures were caused by something (likely dhcp) restarting ntp during test runs. Adding code to the spec_helper_acceptance.rb to remove the ntp exit hook so that ntp doesn't get restarted during tests.