### PR TITLE
Adding ::operatingsystem Amazon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ spec/fixtures/
 coverage/
 .idea/
 *.iml
+log/

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,3 @@ spec/fixtures/
 coverage/
 .idea/
 *.iml
-log/

--- a/.sync.yml
+++ b/.sync.yml
@@ -1,3 +1,9 @@
 ---
+.travis.yml:
+  extras:
+  - rvm: 1.8.7
+    env: PUPPET_GEM_VERSION="~> 2.7.0" FACTER_GEM_VERSION="~> 1.6.0"
+  - rvm: 1.8.7
+    env: PUPPET_GEM_VERSION="~> 2.7.0" FACTER_GEM_VERSION="~> 1.7.0"
 spec/spec_helper.rb:
   unmanaged: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,18 +6,12 @@ script: "bundle exec rake validate && bundle exec rake lint && bundle exec rake 
 matrix:
   fast_finish: true
   include:
-  - rvm: 1.9.3
-    env: PUPPET_GEM_VERSION="~> 3.4.0"
   - rvm: 1.8.7
     env: PUPPET_GEM_VERSION="~> 3.0"
   - rvm: 1.9.3
     env: PUPPET_GEM_VERSION="~> 3.0"
-  - rvm: 1.9.3
-    env: PUPPET_GEM_VERSION="~> 3.0" FUTURE_PARSER="yes"
   - rvm: 2.1.5
     env: PUPPET_GEM_VERSION="~> 3.0"
-  - rvm: 2.1.5
-    env: PUPPET_GEM_VERSION="~> 3.4.0"
   - rvm: 2.1.5
     env: PUPPET_GEM_VERSION="~> 3.0" FUTURE_PARSER="yes"
   - rvm: 1.8.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,14 @@ matrix:
     env: PUPPET_GEM_VERSION="~> 3.0"
   - rvm: 2.1.5
     env: PUPPET_GEM_VERSION="~> 3.0" FUTURE_PARSER="yes"
+  - rvm: 2.1.6
+    env: PUPPET_GEM_VERSION="~> 4.0" STRICT_VARIABLES="yes"
   - rvm: 1.8.7
     env: PUPPET_GEM_VERSION="~> 2.7.0" FACTER_GEM_VERSION="~> 1.6.0"
   - rvm: 1.8.7
     env: PUPPET_GEM_VERSION="~> 2.7.0" FACTER_GEM_VERSION="~> 1.7.0"
+  allow_failures:
+    - rvm: 2.1.6
+      env: PUPPET_GEM_VERSION="~> 4.0" STRICT_VARIABLES="yes"
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,5 @@ matrix:
     env: PUPPET_GEM_VERSION="~> 2.7.0" FACTER_GEM_VERSION="~> 1.6.0"
   - rvm: 1.8.7
     env: PUPPET_GEM_VERSION="~> 2.7.0" FACTER_GEM_VERSION="~> 1.7.0"
-  allow_failures:
-    - rvm: 2.1.6
-      env: PUPPET_GEM_VERSION="~> 4.0" STRICT_VARIABLES="yes"
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,28 @@
 ---
+sudo: false
 language: ruby
 bundler_args: --without system_tests
 script: "bundle exec rake validate && bundle exec rake lint && bundle exec rake spec SPEC_OPTS='--format documentation'"
 matrix:
   fast_finish: true
   include:
+  - rvm: 1.9.3
+    env: PUPPET_GEM_VERSION="~> 3.4.0"
+  - rvm: 1.8.7
+    env: PUPPET_GEM_VERSION="~> 3.0"
+  - rvm: 1.9.3
+    env: PUPPET_GEM_VERSION="~> 3.0"
+  - rvm: 1.9.3
+    env: PUPPET_GEM_VERSION="~> 3.0" FUTURE_PARSER="yes"
+  - rvm: 2.1.5
+    env: PUPPET_GEM_VERSION="~> 3.0"
+  - rvm: 2.1.5
+    env: PUPPET_GEM_VERSION="~> 3.4.0"
+  - rvm: 2.1.5
+    env: PUPPET_GEM_VERSION="~> 3.0" FUTURE_PARSER="yes"
   - rvm: 1.8.7
     env: PUPPET_GEM_VERSION="~> 2.7.0" FACTER_GEM_VERSION="~> 1.6.0"
   - rvm: 1.8.7
     env: PUPPET_GEM_VERSION="~> 2.7.0" FACTER_GEM_VERSION="~> 1.7.0"
-  - rvm: 1.9.3
-    env: PUPPET_GEM_VERSION="~> 3.0"
-  - rvm: 2.0.0
-    env: PUPPET_GEM_VERSION="~> 3.0"
 notifications:
   email: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,34 @@
-## 2015-xx-xx - Supported Release 4.0.0
+## 2015-05-26 - Supported Release 4.0.0
 ### Summary
-This release drops puppet 2.7 support and older stdlib support.
+This release drops puppet 2.7 support and older stdlib support. It also includes the addition of 12 new properties, as well as numerous bug fixes and other improvements.
 
 #### Backwards-incompatible changes
 - UDLC (Undisciplined local clock) is now no longer enabled by default on anything (previous was enabled on non-virtual).
 - Puppet 2.7 no longer supported
 - puppetlabs-stdlib less than 4.5.0 no longer supported
-- TODO: The `keys_file` parent directory is no longer managed by puppet
 
 #### Features
-- TODO
+- Readme, Metadata, and Contribution documentation improvements
+- Acceptance test improvements
+- Added the `broadcastclient` property
+- Added the `disable_auth` property
+- Added `broadcastclient` property
+- Added `disable_auth` property
+- Added `fudge` property
+- Added `peers` property
+- Added `udlc_stratum` property
+- Added `tinker` property
+- Added `minpoll` property
+- Added `maxpoll` property
+- Added `stepout` property
+- Added `leapfile` property
 
 #### Bugfixes
-- TODO
+- Removing equal sign as delimiter in ntp.conf for the logfile parameter.
+- Add package_manage parameter, which is set to false by default on FreeBSD
+- Fixed an issue with the `is_virtual` property
+- Fixed debian wheezy issue
+- Fix for Redhat to disable ntp restart due to dhcp ntp server updates
 
 ##2014-11-04 - Supported Release 3.3.0
 ###Summary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 2015-07-20 - Supported Release 4.1.0
+### Summary
+This release updates metadata to support new version of puppet enterprise, as well as new features, bugfixes, and test improvements.
+
+#### Features
+- Adds support for Solaris 12
+- Adds support for Fedora 20, 21, 22
+
+#### Bugfixes
+- Fix default configuration for Debian (MODULES-2087)
+- Fix to ensure log file is created before service starts
+- Fixes SLES params for SLES 10, 11, 12
+
 ## 2015-05-26 - Supported Release 4.0.0
 ### Summary
 This release drops puppet 2.7 support and older stdlib support. It also includes the addition of 12 new properties, as well as numerous bug fixes and other improvements.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## 2015-xx-xx - Supported Release 4.0.0
+### Summary
+This release drops puppet 2.7 support and older stdlib support.
+
+#### Backwards-incompatible changes
+- UDLC (Undisciplined local clock) is now no longer enabled by default on anything (previous was enabled on non-virtual).
+- Puppet 2.7 no longer supported
+- puppetlabs-stdlib less than 4.5.0 no longer supported
+- TODO: The `keys_file` parent directory is no longer managed by puppet
+
+#### Features
+- TODO
+
+#### Bugfixes
+- TODO
+
 ##2014-11-04 - Supported Release 3.3.0
 ###Summary
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
-## 2015-07-20 - Supported Release 4.1.0
+## 2015-07-21 - Supported Release 4.1.0
 ### Summary
 This release updates metadata to support new version of puppet enterprise, as well as new features, bugfixes, and test improvements.
 
 #### Features
-- Adds support for Solaris 12
-- Adds support for Fedora 20, 21, 22
+- Adds Solaris 10 support
+- Adds Fedora 20, 21, 22 compatibility
 
 #### Bugfixes
 - Fix default configuration for Debian (MODULES-2087)

--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ group :system_tests do
     gem 'beaker-rspec',  :require => false
   end
   gem 'serverspec',    :require => false
+  gem 'beaker-puppet_install_helper', :require => false
 end
 
 

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,6 @@ source ENV['GEM_SOURCE'] || "https://rubygems.org"
 group :development, :unit_tests do
   gem 'rake',                    :require => false
   gem 'rspec-core', '3.1.7',     :require => false
-  gem 'rspec-puppet', '~> 1.0',  :require => false
   gem 'puppetlabs_spec_helper',  :require => false
   gem 'puppet-lint',             :require => false
   gem 'simplecov',               :require => false

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,15 @@
 source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
+def location_for(place, fake_version = nil)
+  if place =~ /^(git:[^#]*)#(.*)/
+    [fake_version, { :git => $1, :branch => $2, :require => false }].compact
+  elsif place =~ /^file:\/\/(.*)/
+    ['>= 0', { :path => File.expand_path($1), :require => false }]
+  else
+    [place, { :require => false }]
+  end
+end
+
 group :development, :unit_tests do
   gem 'rspec-core', '3.1.7',     :require => false
   gem 'puppetlabs_spec_helper',  :require => false
@@ -8,8 +18,17 @@ group :development, :unit_tests do
   gem 'json',                    :require => false
 end
 
+beaker_version = ENV['BEAKER_VERSION']
+beaker_rspec_version = ENV['BEAKER_RSPEC_VERSION']
 group :system_tests do
-  gem 'beaker-rspec',  :require => false
+  if beaker_version
+    gem 'beaker', *location_for(beaker_version)
+  end
+  if beaker_rspec_version
+    gem 'beaker-rspec', *location_for(beaker_rspec_version)
+  else
+    gem 'beaker-rspec',  :require => false
+  end
   gem 'serverspec',    :require => false
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,9 @@ group :development, :unit_tests do
 end
 
 group :system_tests do
+  if beaker_version = ENV['BEAKER_VERSION']
+    gem 'beaker', *location_for(beaker_version)
+  end
   if beaker_rspec_version = ENV['BEAKER_RSPEC_VERSION']
     gem 'beaker-rspec', *location_for(beaker_rspec_version)
   else

--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,8 @@
 source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
 group :development, :unit_tests do
-  gem 'rake',                    :require => false
   gem 'rspec-core', '3.1.7',     :require => false
   gem 'puppetlabs_spec_helper',  :require => false
-  gem 'puppet-lint',             :require => false
   gem 'simplecov',               :require => false
   gem 'puppet_facts',            :require => false
   gem 'json',                    :require => false

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,15 @@
 source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
+def location_for(place, fake_version = nil)
+  if place =~ /^(git:[^#]*)#(.*)/
+    [fake_version, { :git => $1, :branch => $2, :require => false }].compact
+  elsif place =~ /^file:\/\/(.*)/
+    ['>= 0', { :path => File.expand_path($1), :require => false }]
+  else
+    [place, { :require => false }]
+  end
+end
+
 group :development, :unit_tests do
   gem 'rspec-core', '3.1.7',     :require => false
   gem 'puppetlabs_spec_helper',  :require => false
@@ -9,9 +19,15 @@ group :development, :unit_tests do
 end
 
 group :system_tests do
-  gem 'beaker-rspec',  :require => false
+  if beaker_rspec_version = ENV['BEAKER_RSPEC_VERSION']
+    gem 'beaker-rspec', *location_for(beaker_rspec_version)
+  else
+    gem 'beaker-rspec',  :require => false
+  end
   gem 'serverspec',    :require => false
 end
+
+
 
 if facterversion = ENV['FACTER_GEM_VERSION']
   gem 'facter', facterversion, :require => false

--- a/Gemfile
+++ b/Gemfile
@@ -1,15 +1,5 @@
 source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
-def location_for(place, fake_version = nil)
-  if place =~ /^(git:[^#]*)#(.*)/
-    [fake_version, { :git => $1, :branch => $2, :require => false }].compact
-  elsif place =~ /^file:\/\/(.*)/
-    ['>= 0', { :path => File.expand_path($1), :require => false }]
-  else
-    [place, { :require => false }]
-  end
-end
-
 group :development, :unit_tests do
   gem 'rspec-core', '3.1.7',     :require => false
   gem 'puppetlabs_spec_helper',  :require => false
@@ -18,17 +8,8 @@ group :development, :unit_tests do
   gem 'json',                    :require => false
 end
 
-beaker_version = ENV['BEAKER_VERSION']
-beaker_rspec_version = ENV['BEAKER_RSPEC_VERSION']
 group :system_tests do
-  if beaker_version
-    gem 'beaker', *location_for(beaker_version)
-  end
-  if beaker_rspec_version
-    gem 'beaker-rspec', *location_for(beaker_rspec_version)
-  else
-    gem 'beaker-rspec',  :require => false
-  end
+  gem 'beaker-rspec',  :require => false
   gem 'serverspec',    :require => false
 end
 

--- a/README.markdown
+++ b/README.markdown
@@ -291,7 +291,7 @@ Specifies the stratum the server should operate at when using the undisciplined 
 
 ##Limitations
 
-This module has been tested on [all PE-supported platforms](https://forge.puppetlabs.com/supported#compat-matrix), and no issues have been identified.
+This module has been tested on [all PE-supported platforms](https://forge.puppetlabs.com/supported#compat-matrix), and no issues have been identified. Additionally, it is tested (but not supported) on Solaris 12.
 
 ##Development
 

--- a/README.markdown
+++ b/README.markdown
@@ -195,6 +195,14 @@ Provides one or more keys to be trusted by NTP. Valid options: array of keys. De
 
 Specifies a log file for NTP to use instead of syslog. Valid options: string containing an absolute path. Default value: ' '
 
+####`minpoll`
+
+Tells Puppet to use non-standard minimal poll interval of upstream servers. Valid options: 3 to 16. Default option: undef.
+
+####`maxpoll`
+
+Tells Puppet to use non-standard maximal poll interval of upstream servers. Valid options: 3 to 16. Default option: undef, except FreeBSD (on FreeBSD `maxpoll` set 9 by default).
+
 ####`package_ensure`
 
 Tells Puppet whether the NTP package should be installed, and what version. Valid options: 'present', 'latest', or a specific version number. Default value: 'present'
@@ -209,7 +217,7 @@ Tells Puppet what NTP package to manage. Valid options: string. Default value: '
 
 ####`panic`
 
-Specifies whether NTP should "panic" in the event of a very large clock skew. Valid options: 'true' or 'false'. Default value: 'true' (except on virtual machines, where major time shifts are normal)
+Specifies whether NTP should "panic" in the event of a very large clock skew. Applies only if `tinker` option set to "true" or in case your environment is in virtual machine. Valid options: unsigned shortint digit. Default value: 0 if environment is virtual, undef in all other cases.
 
 ####`peers`
 
@@ -260,6 +268,14 @@ Tells Puppet whether to manage the NTP service. Valid options: 'true' or 'false'
 ####`service_name`
 
 Tells Puppet what NTP service to manage. Valid options: string. Default value: varies by operating system
+
+####`stepout`
+
+Tells puppet to change stepout. Applies only if `tinker` value is 'true'. Valid options: unsigned shortint digit. Default value: undef.
+
+####`tinker`
+
+Tells Puppet to enable tinker options. Valid options: 'true' of 'false'. Default value: 'false'
 
 ####`udlc`
 

--- a/README.markdown
+++ b/README.markdown
@@ -277,6 +277,30 @@ Tells Puppet what NTP service to manage. Valid options: string. Default value: v
 
 Tells puppet to change stepout. Applies only if `tinker` value is 'true'. Valid options: unsigned shortint digit. Default value: undef.
 
+####`tos`
+
+Tells Puppet to enable tos options. Valid options: 'true' of 'false'. Default value: 'false'
+
+####`tos_minclock`
+
+Specifies the minclock tos option. Valid options: numeric. Default value: 3
+
+####`tos_minsane`
+
+Specifies the minsane tos option. Valid options: numeric. Default value: 1
+
+####`tos_floor`
+
+Specifies the floor tos option. Valid options: numeric. Default value: 1
+
+####`tos_ceiling`
+
+Specifies the ceiling tos option. Valid options: numeric. Default value: 15
+
+####`tos_cohort`
+
+Specifies the cohort tos option. Valid options: '0' or '1'. Default value: 0
+
 ####`tinker`
 
 Tells Puppet to enable tinker options. Valid options: 'true' of 'false'. Default value: 'false'

--- a/README.markdown
+++ b/README.markdown
@@ -154,7 +154,7 @@ client and symmetric passive associations.
 
 ####`disable_monitor`
 
-Tells Puppet whether to refrain from monitoring the NTP service. Valid options: 'true' or 'false'. Default value: 'false'
+Disables the monitoring facility in NTP. Valid options: 'true' or 'false'. Default value: 'false'
 
 ####`driftfile`
 

--- a/README.markdown
+++ b/README.markdown
@@ -265,6 +265,10 @@ Tells Puppet what NTP service to manage. Valid options: string. Default value: v
 
 Specifies whether to configure ntp to use the undisciplined local clock as a time source. Valid options: 'true' or 'false'. Default value: 'false'
 
+####`udlc_stratum`
+
+Specifies the stratum the server should operate at when using the undisciplined local clock as the time source. It is strongly suggested that this value be set to no less than 10 where ntpd may be accessible outside your immediate, controlled network. Default value: 10
+
 ##Limitations
 
 This module has been tested on [all PE-supported platforms](https://forge.puppetlabs.com/supported#compat-matrix), and no issues have been identified.

--- a/README.markdown
+++ b/README.markdown
@@ -211,6 +211,10 @@ Tells Puppet what NTP package to manage. Valid options: string. Default value: '
 
 Specifies whether NTP should "panic" in the event of a very large clock skew. Valid options: 'true' or 'false'. Default value: 'true' (except on virtual machines, where major time shifts are normal)
 
+####`peers`
+
+List of ntp servers which the local clock can be synchronised against, or which can synchronise against the local clock.
+
 ####`preferred_servers`
 
 Specifies one or more preferred peers. Puppet will append 'prefer' to each matching item in the `servers` array. Valid options: array. Default value: [ ]

--- a/README.markdown
+++ b/README.markdown
@@ -291,7 +291,7 @@ Specifies the stratum the server should operate at when using the undisciplined 
 
 ##Limitations
 
-This module has been tested on [all PE-supported platforms](https://forge.puppetlabs.com/supported#compat-matrix), and no issues have been identified. Additionally, it is tested (but not supported) on Solaris 10 and 12 and Fedora 20-22.
+This module has been tested on [all PE-supported platforms](https://forge.puppetlabs.com/supported#compat-matrix), and no issues have been identified. Additionally, it is tested (but not supported) on Solaris 10 and Fedora 20-22.
 
 ##Development
 

--- a/README.markdown
+++ b/README.markdown
@@ -191,6 +191,10 @@ Provides a request key to be used by NTP. Valid options: string. Default value: 
 #### `keys_trusted`:
 Provides one or more keys to be trusted by NTP. Valid options: array of keys. Default value: [ ]
 
+#### `leapfile`
+
+Specifies a leap second file for NTP to use. Valid options: string containing an absolute path. Default value: ' '
+
 #### `logfile`
 
 Specifies a log file for NTP to use instead of syslog. Valid options: string containing an absolute path. Default value: ' '

--- a/README.markdown
+++ b/README.markdown
@@ -259,7 +259,7 @@ Tells Puppet what NTP service to manage. Valid options: string. Default value: v
 
 ####`udlc`
 
-Specifies whether to configure ntp to use the undisciplined local clock as a time source, regardless of the node's status as a virtual machine. Valid options: 'true' or 'false'. Default value: 'false' for VMs and 'true' otherwise.
+Specifies whether to configure ntp to use the undisciplined local clock as a time source. Valid options: 'true' or 'false'. Default value: 'false'
 
 ##Limitations
 

--- a/README.markdown
+++ b/README.markdown
@@ -152,6 +152,10 @@ Specifies a file to act as a template for the config file. Valid options: string
 Do  not  require cryptographic authentication for broadcast client, multicast 
 client and symmetric passive associations.
 
+####`disable_auth`
+
+Disable kernel time discipline.
+
 ####`disable_monitor`
 
 Disables the monitoring facility in NTP. Valid options: 'true' or 'false'. Default value: 'false'

--- a/README.markdown
+++ b/README.markdown
@@ -291,7 +291,7 @@ Specifies the stratum the server should operate at when using the undisciplined 
 
 ##Limitations
 
-This module has been tested on [all PE-supported platforms](https://forge.puppetlabs.com/supported#compat-matrix), and no issues have been identified. Additionally, it is tested (but not supported) on Solaris 10 and 12.
+This module has been tested on [all PE-supported platforms](https://forge.puppetlabs.com/supported#compat-matrix), and no issues have been identified. Additionally, it is tested (but not supported) on Solaris 10 and 12 and Fedora 20-22.
 
 ##Development
 

--- a/README.markdown
+++ b/README.markdown
@@ -160,6 +160,10 @@ Tells Puppet whether to refrain from monitoring the NTP service. Valid options: 
 
 Specifies an NTP driftfile. Valid options: string containing an absolute path. Default value: '/var/lib/ntp/drift' (except on AIX and Solaris)
 
+#### `fudge`
+
+Used to provide additional information for individual clock drivers. Valid options: array containing strings that follow the `fudge` command. Default value: [ ]
+
 ####`iburst_enable`
 
 Specifies whether to enable the iburst option for every NTP peer. Valid options: 'true' or 'false'. Default value: 'false' (except on AIX and Debian)

--- a/README.markdown
+++ b/README.markdown
@@ -291,7 +291,7 @@ Specifies the stratum the server should operate at when using the undisciplined 
 
 ##Limitations
 
-This module has been tested on [all PE-supported platforms](https://forge.puppetlabs.com/supported#compat-matrix), and no issues have been identified. Additionally, it is tested (but not supported) on Solaris 12.
+This module has been tested on [all PE-supported platforms](https://forge.puppetlabs.com/supported#compat-matrix), and no issues have been identified. Additionally, it is tested (but not supported) on Solaris 10 and 12.
 
 ##Development
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,7 @@
 require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-lint/tasks/puppet-lint'
 
-PuppetLint.configuration.fail_on_warnings
+PuppetLint.configuration.fail_on_warnings = true
 PuppetLint.configuration.send('relative')
 PuppetLint.configuration.send('disable_80chars')
 PuppetLint.configuration.send('disable_class_inherits_from_params_class')

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,22 +1,22 @@
 #
 class ntp::config inherits ntp {
 
-  if $keys_enable {
-    $directory = ntp_dirname($keys_file)
+  if $ntp::keys_enable {
+    $directory = ntp_dirname($ntp::keys_file)
     file { $directory:
-      ensure  => directory,
-      owner   => 0,
-      group   => 0,
-      mode    => '0755',
+      ensure => directory,
+      owner  => 0,
+      group  => 0,
+      mode   => '0755',
     }
   }
 
-  file { $config:
+  file { $ntp::config:
     ensure  => file,
     owner   => 0,
     group   => 0,
     mode    => '0644',
-    content => template($config_template),
+    content => template($ntp::config_template),
   }
 
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -19,4 +19,13 @@ class ntp::config inherits ntp {
     content => template($ntp::config_template),
   }
 
+  if $ntp::logfile {
+    file { $ntp::logfile:
+      ensure => 'file',
+      owner  => 'ntp',
+      group  => 'ntp',
+      mode   => '0664',
+    }
+  }
+
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,6 +4,7 @@ class ntp (
   $config            = $ntp::params::config,
   $config_template   = $ntp::params::config_template,
   $disable_auth      = $ntp::params::disable_auth,
+  $disable_kernel    = $ntp::params::disable_kernel,
   $disable_monitor   = $ntp::params::disable_monitor,
   $fudge             = $ntp::params::fudge,
   $driftfile         = $ntp::params::driftfile,
@@ -46,6 +47,7 @@ class ntp (
   validate_absolute_path($config)
   validate_string($config_template)
   validate_bool($disable_auth)
+  validate_bool($disable_kernel)
   validate_bool($disable_monitor)
   validate_absolute_path($driftfile)
   if $logfile { validate_absolute_path($logfile) }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,6 +18,7 @@ class ntp (
   $package_manage    = $ntp::params::package_manage,
   $package_name      = $ntp::params::package_name,
   $panic             = $ntp::params::panic,
+  $peers             = $ntp::params::peers,
   $preferred_servers = $ntp::params::preferred_servers,
   $restrict          = $ntp::params::restrict,
   $interfaces        = $ntp::params::interfaces,
@@ -26,7 +27,7 @@ class ntp (
   $service_ensure    = $ntp::params::service_ensure,
   $service_manage    = $ntp::params::service_manage,
   $service_name      = $ntp::params::service_name,
-  $udlc              = $ntp::params::udlc
+  $udlc              = $ntp::params::udlc,
 ) inherits ntp::params {
 
   validate_bool($broadcastclient)
@@ -55,6 +56,7 @@ class ntp (
   validate_bool($service_manage)
   validate_string($service_name)
   validate_bool($udlc)
+  validate_array($peers)
 
   if $autoupdate {
     notice('autoupdate parameter has been deprecated and replaced with package_ensure.  Set this to latest for the same behavior as autoupdate => true.')

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -32,6 +32,12 @@ class ntp (
   $service_name      = $ntp::params::service_name,
   $stepout           = $ntp::params::stepout,
   $tinker            = $ntp::params::tinker,
+  $tos               = $ntp::params::tos,
+  $tos_minclock      = $ntp::params::tos_minclock,
+  $tos_minsane       = $ntp::params::tos_minsane,
+  $tos_floor         = $ntp::params::tos_floor,
+  $tos_ceiling       = $ntp::params::tos_ceiling,
+  $tos_cohort        = $ntp::params::tos_cohort,
   $udlc              = $ntp::params::udlc,
   $udlc_stratum      = $ntp::params::udlc_stratum,
 ) inherits ntp::params {
@@ -66,6 +72,12 @@ class ntp (
   validate_string($service_name)
   if $stepout { validate_numeric($stepout, 65535, 0) }
   validate_bool($tinker)
+  validate_bool($tos)
+  if $tos_minclock { validate_numeric($tos_minclock) }
+  if $tos_minsane { validate_numeric($tos_minsane) }
+  if $tos_floor { validate_numeric($tos_floor) }
+  if $tos_ceiling { validate_numeric($tos_ceiling) }
+  if $tos_cohort { validate_re($tos_cohort, '^[0|1]$', "Must be 0 or 1, got: ${tos_cohort}") }
   validate_bool($udlc)
   validate_array($peers)
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,6 +5,7 @@ class ntp (
   $config_template   = $ntp::params::config_template,
   $disable_auth      = $ntp::params::disable_auth,
   $disable_monitor   = $ntp::params::disable_monitor,
+  $fudge             = $ntp::params::fudge,
   $driftfile         = $ntp::params::driftfile,
   $logfile           = $ntp::params::logfile,
   $iburst_enable     = $ntp::params::iburst_enable,
@@ -48,6 +49,7 @@ class ntp (
   validate_array($restrict)
   validate_array($interfaces)
   validate_array($servers)
+  validate_array($fudge)
   validate_bool($service_enable)
   validate_string($service_ensure)
   validate_bool($service_manage)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,6 +14,8 @@ class ntp (
   $keys_controlkey   = $ntp::params::keys_controlkey,
   $keys_requestkey   = $ntp::params::keys_requestkey,
   $keys_trusted      = $ntp::params::keys_trusted,
+  $minpoll           = $ntp::params::minpoll,
+  $maxpoll           = $ntp::params::maxpoll,
   $package_ensure    = $ntp::params::package_ensure,
   $package_manage    = $ntp::params::package_manage,
   $package_name      = $ntp::params::package_name,
@@ -27,6 +29,8 @@ class ntp (
   $service_ensure    = $ntp::params::service_ensure,
   $service_manage    = $ntp::params::service_manage,
   $service_name      = $ntp::params::service_name,
+  $stepout           = $ntp::params::stepout,
+  $tinker            = $ntp::params::tinker,
   $udlc              = $ntp::params::udlc,
   $udlc_stratum      = $ntp::params::udlc_stratum,
 ) inherits ntp::params {
@@ -43,10 +47,12 @@ class ntp (
   validate_re($keys_controlkey, ['^\d+$', ''])
   validate_re($keys_requestkey, ['^\d+$', ''])
   validate_array($keys_trusted)
+  if $minpoll { validate_numeric($minpoll, 16, 3) }
+  if $maxpoll { validate_numeric($maxpoll, 16, 3) }
   validate_string($package_ensure)
   validate_bool($package_manage)
   validate_array($package_name)
-  validate_bool($panic)
+  if $panic { validate_numeric($panic, 65535, 0) }
   validate_array($preferred_servers)
   validate_array($restrict)
   validate_array($interfaces)
@@ -56,6 +62,8 @@ class ntp (
   validate_string($service_ensure)
   validate_bool($service_manage)
   validate_string($service_name)
+  if $stepout { validate_numeric($stepout, 65535, 0) }
+  validate_bool($tinker)
   validate_bool($udlc)
   validate_array($peers)
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -28,6 +28,7 @@ class ntp (
   $service_manage    = $ntp::params::service_manage,
   $service_name      = $ntp::params::service_name,
   $udlc              = $ntp::params::udlc,
+  $udlc_stratum      = $ntp::params::udlc_stratum,
 ) inherits ntp::params {
 
   validate_bool($broadcastclient)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,6 +7,7 @@ class ntp (
   $disable_monitor   = $ntp::params::disable_monitor,
   $fudge             = $ntp::params::fudge,
   $driftfile         = $ntp::params::driftfile,
+  $leapfile          = $ntp::params::leapfile,
   $logfile           = $ntp::params::logfile,
   $iburst_enable     = $ntp::params::iburst_enable,
   $keys_enable       = $ntp::params::keys_enable,
@@ -42,6 +43,7 @@ class ntp (
   validate_bool($disable_monitor)
   validate_absolute_path($driftfile)
   if $logfile { validate_absolute_path($logfile) }
+  if $leapfile { validate_absolute_path($leapfile) }
   validate_bool($iburst_enable)
   validate_bool($keys_enable)
   validate_re($keys_controlkey, ['^\d+$', ''])

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,10 +1,10 @@
 #
 class ntp::install inherits ntp {
 
-  if $package_manage {
+  if $ntp::package_manage {
 
-    package { $package_name:
-      ensure => $package_ensure,
+    package { $ntp::package_name:
+      ensure => $ntp::package_ensure,
     }
 
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -72,7 +72,7 @@ class ntp::params {
       $driftfile       = $default_driftfile
       $package_name    = $default_package_name
       $restrict        = [
-        '-4 kod nomodify notrap nopeer noquery',
+        '-4 default kod nomodify notrap nopeer noquery',
         '-6 default kod nomodify notrap nopeer noquery',
         '127.0.0.1',
         '::1',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -180,17 +180,24 @@ class ntp::params {
       $config        = '/etc/inet/ntp.conf'
       $driftfile     = '/var/ntp/ntp.drift'
       $keys_file     = '/etc/inet/ntp.keys'
-      $package_name  = $::operatingsystemrelease ? {
-        /^(5\.10|10|10_u\d+)$/ => [ 'SUNWntpr', 'SUNWntpu' ],
-        /^(5\.11|11|11\.\d+)$/ => [ 'service/network/ntp' ],
-        /^(5\.12|12|12\.\d+)$/ => [ 'service/network/ntp' ]
+      if $::operatingsystemrelease =~ /^(5\.10|10|10_u\d+)$/
+      {
+        # Solaris 10
+        $package_name = [ 'SUNWntpr', 'SUNWntpu' ]
+        $restrict     = [
+          'default nomodify notrap nopeer noquery',
+          '127.0.0.1',
+        ]
+      } else {
+        # Solaris 11, 12 ...
+        $package_name = [ 'service/network/ntp' ]
+        $restrict     = [
+          'default kod nomodify notrap nopeer noquery',
+          '-6 default kod nomodify notrap nopeer noquery',
+          '127.0.0.1',
+          '-6 ::1',
+        ]
       }
-      $restrict      = [
-        'default kod nomodify notrap nopeer noquery',
-        '-6 default kod nomodify notrap nopeer noquery',
-        '127.0.0.1',
-        '-6 ::1',
-      ]
       $service_name  = 'network/ntp'
       $iburst_enable = false
       $servers       = [

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -21,6 +21,12 @@ class ntp::params {
   $interfaces        = []
   $disable_auth      = false
   $broadcastclient   = false
+  $tos               = false
+  $tos_minclock      = '3'
+  $tos_minsane       = '1'
+  $tos_floor         = '1'
+  $tos_ceiling       = '15'
+  $tos_cohort        = '0'
 
   # Allow a list of fudge options
   $fudge             = []

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -15,6 +15,7 @@ class ntp::params {
   $service_ensure    = 'running'
   $service_manage    = true
   $udlc              = false
+  $udlc_stratum      = '10'
   $interfaces        = []
   $disable_auth      = false
   $broadcastclient   = false

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,6 +9,7 @@ class ntp::params {
   $keys_trusted      = []
   $logfile           = undef
   $package_ensure    = 'present'
+  $peers             = []
   $preferred_servers = []
   $service_enable    = true
   $service_ensure    = 'running'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -17,6 +17,9 @@ class ntp::params {
   $disable_auth      = false
   $broadcastclient   = false
 
+  # Allow a list of fudge options
+  $fudge             = []
+
   # On virtual machines allow large clock skews.
   # TODO Change this to str2bool($::is_virtual) when stdlib dependency is >= 4.0.0
   # NOTE The "x${var}" is just to avoid lint quoted variable warning.

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,6 +9,7 @@ class ntp::params {
   $keys_trusted      = []
   $logfile           = undef
   $minpoll           = undef
+  $leapfile          = undef
   $package_ensure    = 'present'
   $peers             = []
   $preferred_servers = []

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,12 +8,14 @@ class ntp::params {
   $keys_requestkey   = ''
   $keys_trusted      = []
   $logfile           = undef
+  $minpoll           = undef
   $package_ensure    = 'present'
   $peers             = []
   $preferred_servers = []
   $service_enable    = true
   $service_ensure    = 'running'
   $service_manage    = true
+  $stepout           = undef
   $udlc              = false
   $udlc_stratum      = '10'
   $interfaces        = []
@@ -22,14 +24,6 @@ class ntp::params {
 
   # Allow a list of fudge options
   $fudge             = []
-
-  # On virtual machines allow large clock skews.
-  # TODO Change this to str2bool($::is_virtual) when stdlib dependency is >= 4.0.0
-  # NOTE The "x${var}" is just to avoid lint quoted variable warning.
-  $panic = "x${::is_virtual}" ? {
-    'xtrue' => false,
-    default => true,
-  }
 
   $default_config       = '/etc/ntp.conf'
   $default_keys_file    = '/etc/ntp/keys'
@@ -40,6 +34,15 @@ class ntp::params {
   $package_manage = $::osfamily ? {
     'FreeBSD' => false,
     default   => true,
+  }
+
+  if str2bool($::is_virtual) {
+    $tinker = true
+    $panic  = 0
+  }
+  else {
+    $tinker = false
+    $panic  = undef
   }
 
   case $::osfamily {
@@ -60,6 +63,7 @@ class ntp::params {
         '2.debian.pool.ntp.org',
         '3.debian.pool.ntp.org',
       ]
+      $maxpoll       = undef
     }
     'Debian': {
       $config          = $default_config
@@ -80,6 +84,7 @@ class ntp::params {
         '2.debian.pool.ntp.org',
         '3.debian.pool.ntp.org',
       ]
+      $maxpoll         = undef
     }
     'RedHat': {
       $config          = $default_config
@@ -99,6 +104,7 @@ class ntp::params {
         '1.centos.pool.ntp.org',
         '2.centos.pool.ntp.org',
       ]
+      $maxpoll         = undef
     }
     'Suse': {
       if $::operatingsystem == 'SLES' and $::operatingsystemmajrelease == '12'
@@ -125,6 +131,7 @@ class ntp::params {
         '2.opensuse.pool.ntp.org',
         '3.opensuse.pool.ntp.org',
       ]
+      $maxpoll         = undef
     }
     'FreeBSD': {
       $config          = $default_config
@@ -140,11 +147,12 @@ class ntp::params {
       $service_name    = $default_service_name
       $iburst_enable   = true
       $servers         = [
-        '0.freebsd.pool.ntp.org maxpoll 9',
-        '1.freebsd.pool.ntp.org maxpoll 9',
-        '2.freebsd.pool.ntp.org maxpoll 9',
-        '3.freebsd.pool.ntp.org maxpoll 9',
+        '0.freebsd.pool.ntp.org',
+        '1.freebsd.pool.ntp.org',
+        '2.freebsd.pool.ntp.org',
+        '3.freebsd.pool.ntp.org',
       ]
+      $maxpoll         = 9
     }
     'Archlinux': {
       $config          = $default_config
@@ -164,6 +172,7 @@ class ntp::params {
         '1.pool.ntp.org',
         '2.pool.ntp.org',
       ]
+      $maxpoll         = undef
     }
     'Solaris': {
       $config        = '/etc/inet/ntp.conf'
@@ -187,6 +196,7 @@ class ntp::params {
         '2.pool.ntp.org',
         '3.pool.ntp.org',
       ]
+      $maxpoll       = undef
     }
   # Gentoo was added as its own $::osfamily in Facter 1.7.0
     'Gentoo': {
@@ -208,6 +218,7 @@ class ntp::params {
         '2.gentoo.pool.ntp.org',
         '3.gentoo.pool.ntp.org',
       ]
+      $maxpoll         = undef
     }
     'Linux': {
     # Account for distributions that don't have $::osfamily specific settings.
@@ -232,6 +243,7 @@ class ntp::params {
             '2.gentoo.pool.ntp.org',
             '3.gentoo.pool.ntp.org',
           ]
+          $maxpoll         = undef
         }
         default: {
           fail("The ${module_name} module is not supported on an ${::operatingsystem} distribution.")

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -182,7 +182,8 @@ class ntp::params {
       $keys_file     = '/etc/inet/ntp.keys'
       $package_name  = $::operatingsystemrelease ? {
         /^(5\.10|10|10_u\d+)$/ => [ 'SUNWntpr', 'SUNWntpu' ],
-        /^(5\.11|11|11\.\d+)$/ => [ 'service/network/ntp' ]
+        /^(5\.11|11|11\.\d+)$/ => [ 'service/network/ntp' ],
+        /^(5\.12|12|12\.\d+)$/ => [ 'service/network/ntp' ]
       }
       $restrict      = [
         'default kod nomodify notrap nopeer noquery',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -2,7 +2,6 @@ class ntp::params {
 
   $autoupdate        = false
   $config_template   = 'ntp/ntp.conf.erb'
-  $disable_monitor   = false
   $keys_enable       = false
   $keys_controlkey   = ''
   $keys_requestkey   = ''
@@ -48,23 +47,24 @@ class ntp::params {
 
   case $::osfamily {
     'AIX': {
-      $config        = $default_config
-      $keys_file     = '/etc/ntp.keys'
-      $driftfile     = '/etc/ntp.drift'
-      $package_name  = [ 'bos.net.tcp.client' ]
-      $restrict      = [
+      $config          = $default_config
+      $keys_file       = '/etc/ntp.keys'
+      $driftfile       = '/etc/ntp.drift'
+      $package_name    = [ 'bos.net.tcp.client' ]
+      $restrict        = [
         'default nomodify notrap nopeer noquery',
         '127.0.0.1',
       ]
-      $service_name  = 'xntpd'
-      $iburst_enable = true
-      $servers       = [
+      $service_name    = 'xntpd'
+      $iburst_enable   = true
+      $servers         = [
         '0.debian.pool.ntp.org',
         '1.debian.pool.ntp.org',
         '2.debian.pool.ntp.org',
         '3.debian.pool.ntp.org',
       ]
-      $maxpoll       = undef
+      $maxpoll         = undef
+      $disable_monitor = false
     }
     'Debian': {
       $config          = $default_config
@@ -86,6 +86,7 @@ class ntp::params {
         '3.debian.pool.ntp.org',
       ]
       $maxpoll         = undef
+      $disable_monitor = false
     }
     'RedHat': {
       $config          = $default_config
@@ -93,19 +94,40 @@ class ntp::params {
       $driftfile       = $default_driftfile
       $package_name    = $default_package_name
       $service_name    = $default_service_name
-      $restrict        = [
-        'default kod nomodify notrap nopeer noquery',
-        '-6 default kod nomodify notrap nopeer noquery',
-        '127.0.0.1',
-        '-6 ::1',
-      ]
-      $iburst_enable   = false
-      $servers         = [
-        '0.centos.pool.ntp.org',
-        '1.centos.pool.ntp.org',
-        '2.centos.pool.ntp.org',
-      ]
       $maxpoll         = undef
+
+      case $::operatingsystem {
+        'Fedora': {
+          $restrict        = [
+            'default nomodify notrap nopeer noquery',
+            '127.0.0.1',
+            '::1',
+          ]
+          $iburst_enable   = true
+          $servers         = [
+            '0.fedora.pool.ntp.org',
+            '1.fedora.pool.ntp.org',
+            '2.fedora.pool.ntp.org',
+            '3.fedora.pool.ntp.org',
+          ]
+          $disable_monitor = true
+        }
+        default: {
+          $restrict        = [
+            'default kod nomodify notrap nopeer noquery',
+            '-6 default kod nomodify notrap nopeer noquery',
+            '127.0.0.1',
+            '-6 ::1',
+          ]
+          $iburst_enable   = false
+          $servers         = [
+            '0.centos.pool.ntp.org',
+            '1.centos.pool.ntp.org',
+            '2.centos.pool.ntp.org',
+          ]
+          $disable_monitor = false
+        }
+      }
     }
     'Suse': {
       if $::operatingsystem == 'SLES' and $::operatingsystemmajrelease == '12'
@@ -133,6 +155,7 @@ class ntp::params {
         '3.opensuse.pool.ntp.org',
       ]
       $maxpoll         = undef
+      $disable_monitor = false
     }
     'FreeBSD': {
       $config          = $default_config
@@ -154,6 +177,7 @@ class ntp::params {
         '3.freebsd.pool.ntp.org',
       ]
       $maxpoll         = 9
+      $disable_monitor = false
     }
     'Archlinux': {
       $config          = $default_config
@@ -175,6 +199,7 @@ class ntp::params {
         '3.arch.pool.ntp.org',
       ]
       $maxpoll         = undef
+      $disable_monitor = false
     }
     'Solaris': {
       $config        = '/etc/inet/ntp.conf'
@@ -207,6 +232,7 @@ class ntp::params {
         '3.pool.ntp.org',
       ]
       $maxpoll       = undef
+      $disable_monitor = false
     }
   # Gentoo was added as its own $::osfamily in Facter 1.7.0
     'Gentoo': {
@@ -229,6 +255,7 @@ class ntp::params {
         '3.gentoo.pool.ntp.org',
       ]
       $maxpoll         = undef
+      $disable_monitor = false
     }
     'Linux': {
     # Account for distributions that don't have $::osfamily specific settings.
@@ -254,6 +281,7 @@ class ntp::params {
             '3.gentoo.pool.ntp.org',
           ]
           $maxpoll         = undef
+          $disable_monitor = false
         }
         default: {
           fail("The ${module_name} module is not supported on an ${::operatingsystem} distribution.")

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -231,7 +231,7 @@ class ntp::params {
           '127.0.0.1',
         ]
       } else {
-        # Solaris 11, 12 ...
+        # Solaris 11...
         $package_name = [ 'service/network/ntp' ]
         $restrict     = [
           'default kod nomodify notrap nopeer noquery',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -158,7 +158,7 @@ class ntp::params {
     'Archlinux': {
       $config          = $default_config
       $keys_file       = $default_keys_file
-      $driftfile       = $default_driftfile
+      $driftfile       = '/var/lib/ntp/ntp.drift'
       $package_name    = $default_package_name
       $service_name    = $default_service_name
       $restrict        = [
@@ -169,9 +169,10 @@ class ntp::params {
       ]
       $iburst_enable   = false
       $servers         = [
-        '0.pool.ntp.org',
-        '1.pool.ntp.org',
-        '2.pool.ntp.org',
+        '0.arch.pool.ntp.org',
+        '1.arch.pool.ntp.org',
+        '2.arch.pool.ntp.org',
+        '3.arch.pool.ntp.org',
       ]
       $maxpoll         = undef
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -20,6 +20,7 @@ class ntp::params {
   $udlc_stratum      = '10'
   $interfaces        = []
   $disable_auth      = false
+  $disable_kernel    = false
   $broadcastclient   = false
   $tos               = false
   $tos_minclock      = '3'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -130,17 +130,34 @@ class ntp::params {
       }
     }
     'Suse': {
-      if $::operatingsystem == 'SLES' and $::operatingsystemmajrelease == '12'
-      {
-        $service_name  = 'ntpd'
-        $keys_file     = '/etc/ntp.keys'
-      } else{
+      if $::operatingsystem == 'SLES' {
+        case $::operatingsystemmajrelease {
+          '10': {
+            $service_name  = 'ntp'
+            $keys_file     = '/etc/ntp.keys'
+            $package_name  = [ 'xntp' ]
+          }
+          '11': {
+            $service_name  = 'ntp'
+            $keys_file     = $default_keys_file
+            $package_name  = $default_package_name
+          }
+          '12': {
+            $service_name  = 'ntpd'
+            $keys_file     = '/etc/ntp.keys'
+            $package_name  = $default_package_name
+          }
+          default: {
+            fail("The ${module_name} module is not supported on an ${::operatingsystem} ${::operatingsystemmajrelease} distribution.")
+          }
+        }
+      } else {
         $service_name  = 'ntp'
         $keys_file     = $default_keys_file
+        $package_name  = $default_package_name
       }
       $config          = $default_config
       $driftfile       = '/var/lib/ntp/drift/ntp.drift'
-      $package_name    = $default_package_name
       $restrict        = [
         'default kod nomodify notrap nopeer noquery',
         '-6 default kod nomodify notrap nopeer noquery',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -70,10 +70,10 @@ class ntp::params {
       $driftfile       = $default_driftfile
       $package_name    = $default_package_name
       $restrict        = [
-        'default kod nomodify notrap nopeer noquery',
+        '-4 kod nomodify notrap nopeer noquery',
         '-6 default kod nomodify notrap nopeer noquery',
         '127.0.0.1',
-        '-6 ::1',
+        '::1',
       ]
       $service_name    = 'ntp'
       $iburst_enable   = true

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -307,6 +307,27 @@ class ntp::params {
           $maxpoll         = undef
           $disable_monitor = false
         }
+        'Amazon': {
+          $config          = $default_config
+          $keys_file       = $default_keys_file
+          $driftfile       = $default_driftfile
+          $package_name    = $default_package_name
+          $service_name    = $default_service_name
+          $restrict        = [
+            'default kod nomodify notrap nopeer noquery',
+            '-6 default kod nomodify notrap nopeer noquery',
+            '127.0.0.1',
+            '-6 ::1',
+          ]
+          $iburst_enable   = false
+          $servers         = [
+            '0.centos.pool.ntp.org',
+            '1.centos.pool.ntp.org',
+            '2.centos.pool.ntp.org',
+          ]
+          $maxpoll         = undef
+          $disable_monitor = false
+        }
         default: {
           fail("The ${module_name} module is not supported on an ${::operatingsystem} distribution.")
         }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -229,7 +229,7 @@ class ntp::params {
       $config        = '/etc/inet/ntp.conf'
       $driftfile     = '/var/ntp/ntp.drift'
       $keys_file     = '/etc/inet/ntp.keys'
-      if $::operatingsystemrelease =~ /^(5\.10|10|10_u\d+)$/
+      if $::kernelrelease == '5.10'
       {
         # Solaris 10
         $package_name = [ 'SUNWntpr', 'SUNWntpu' ]

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -13,6 +13,7 @@ class ntp::params {
   $service_enable    = true
   $service_ensure    = 'running'
   $service_manage    = true
+  $udlc              = false
   $interfaces        = []
   $disable_auth      = false
   $broadcastclient   = false
@@ -24,15 +25,6 @@ class ntp::params {
   # TODO Change this to str2bool($::is_virtual) when stdlib dependency is >= 4.0.0
   # NOTE The "x${var}" is just to avoid lint quoted variable warning.
   $panic = "x${::is_virtual}" ? {
-    'xtrue' => false,
-    default => true,
-  }
-
-  # On virtual systems, disable the use of the undisciplined local clock to
-  # avoid ntp falling back to the local clock in preference over ntp servers.
-  # TODO Change this to str2bool($::is_virtual) when stdlib dependency is >= 4
-  # NOTE The "x${var}" is just to avoid lint quoted variable warning.
-  $udlc = "x${::is_virtual}" ? {
     'xtrue' => false,
     default => true,
   }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,15 +1,15 @@
 #
 class ntp::service inherits ntp {
 
-  if ! ($service_ensure in [ 'running', 'stopped' ]) {
+  if ! ($ntp::service_ensure in [ 'running', 'stopped' ]) {
     fail('service_ensure parameter must be running or stopped')
   }
 
-  if $service_manage == true {
+  if $ntp::service_manage == true {
     service { 'ntp':
-      ensure     => $service_ensure,
-      enable     => $service_enable,
-      name       => $service_name,
+      ensure     => $ntp::service_ensure,
+      enable     => $ntp::service_enable,
+      name       => $ntp::service_name,
       hasstatus  => true,
       hasrestart => true,
     }

--- a/metadata.json
+++ b/metadata.json
@@ -90,6 +90,6 @@
   ],
   "description": "NTP Module for Debian, Ubuntu, CentOS, RHEL, OEL, Fedora, FreeBSD, ArchLinux and Gentoo.",
   "dependencies": [
-    {"name":"puppetlabs/stdlib","version_requirement":">= 4.5.0 < 5.0.0"}
+    {"name":"puppetlabs/stdlib","version_requirement":">= 4.6.0 < 5.0.0"}
   ]
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-ntp",
-  "version": "3.3.0",
+  "version": "4.0.0",
   "author": "Puppet Labs",
   "summary": "Installs, configures, and manages the NTP service.",
   "license": "Apache Version 2.0",

--- a/metadata.json
+++ b/metadata.json
@@ -81,7 +81,7 @@
   "requirements": [
     {
       "name": "pe",
-      "version_requirement": "3.x"
+      "version_requirement": ">= 3.7.0 < 4.0.0"
     },
     {
       "name": "puppet",
@@ -90,6 +90,6 @@
   ],
   "description": "NTP Module for Debian, Ubuntu, CentOS, RHEL, OEL, Fedora, FreeBSD, ArchLinux and Gentoo.",
   "dependencies": [
-    {"name":"puppetlabs/stdlib","version_requirement":">= 3.2.0 < 5.0.0"}
+    {"name":"puppetlabs/stdlib","version_requirement":">= 4.5.0 < 5.0.0"}
   ]
 }

--- a/metadata.json
+++ b/metadata.json
@@ -84,6 +84,15 @@
         "6.1",
         "7.1"
       ]
+    },
+    {
+      "operatingsystem": "Amazon",
+      "operatingsystemrelease": [
+        "2013.09",
+        "2014.03",
+        "2014.09",
+        "2015.03"
+      ]
     }
   ],
   "requirements": [
@@ -96,7 +105,7 @@
       "version_requirement": ">= 3.0.0 < 5.0.0"
     }
   ],
-  "description": "NTP Module for Debian, Ubuntu, CentOS, RHEL, OEL, Fedora, FreeBSD, ArchLinux and Gentoo.",
+  "description": "NTP Module for Debian, Ubuntu, CentOS, RHEL, OEL, Fedora, FreeBSD, ArchLinux, Amazon Linux and Gentoo.",
   "dependencies": [
     {"name":"puppetlabs/stdlib","version_requirement":">= 4.6.0 < 5.0.0"}
   ]

--- a/metadata.json
+++ b/metadata.json
@@ -66,7 +66,8 @@
     {
       "operatingsystem": "Solaris",
       "operatingsystemrelease": [
-        "11"
+        "11",
+        "12"
       ]
     },
     {

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-ntp",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "author": "Puppet Labs",
   "summary": "Installs, configures, and manages the NTP service.",
   "license": "Apache Version 2.0",
@@ -91,11 +91,11 @@
   "requirements": [
     {
       "name": "pe",
-      "version_requirement": ">= 3.7.0 < 4.0.0"
+      "version_requirement": ">= 3.7.0 < 2015.3.0"
     },
     {
       "name": "puppet",
-      "version_requirement": "3.x"
+      "version_requirement": ">= 3.0.0 < 5.0.0"
     }
   ],
   "description": "NTP Module for Debian, Ubuntu, CentOS, RHEL, OEL, Fedora, FreeBSD, ArchLinux and Gentoo.",

--- a/metadata.json
+++ b/metadata.json
@@ -66,6 +66,7 @@
     {
       "operatingsystem": "Solaris",
       "operatingsystemrelease": [
+        "10",
         "11",
         "12"
       ]

--- a/metadata.json
+++ b/metadata.json
@@ -74,6 +74,7 @@
     {
       "operatingsystem": "Solaris",
       "operatingsystemrelease": [
+        "10",
         "11",
         "12"
       ]

--- a/metadata.json
+++ b/metadata.json
@@ -74,8 +74,7 @@
     {
       "operatingsystem": "Solaris",
       "operatingsystemrelease": [
-        "11",
-        "12"
+        "11"
       ]
     },
     {

--- a/metadata.json
+++ b/metadata.json
@@ -41,6 +41,14 @@
       ]
     },
     {
+      "operatingsystem": "Fedora",
+      "operatingsystemrelease": [
+        "20",
+        "21",
+        "22"
+      ]
+    },
+    {
       "operatingsystem": "SLES",
       "operatingsystemrelease": [
         "10 SP4",

--- a/metadata.json
+++ b/metadata.json
@@ -74,7 +74,8 @@
     {
       "operatingsystem": "Solaris",
       "operatingsystemrelease": [
-        "11"
+        "11",
+        "12"
       ]
     },
     {

--- a/metadata.json
+++ b/metadata.json
@@ -74,9 +74,7 @@
     {
       "operatingsystem": "Solaris",
       "operatingsystemrelease": [
-        "10",
-        "11",
-        "12"
+        "11"
       ]
     },
     {

--- a/spec/acceptance/nodesets/fedora-21-x64.yml
+++ b/spec/acceptance/nodesets/fedora-21-x64.yml
@@ -1,0 +1,9 @@
+HOSTS:
+  fedora-21:
+    roles:
+      - master
+    platform: fedora-21-x86_64
+    box: chef/fedora-21
+    hypervisor: vagrant
+CONFIG:
+  type: foss

--- a/spec/acceptance/ntp_config_spec.rb
+++ b/spec/acceptance/ntp_config_spec.rb
@@ -14,7 +14,7 @@ when 'Gentoo'
 when 'Linux'
   case fact('operatingsystem')
   when 'ArchLinux'
-    line = '0.pool.ntp.org'
+    line = '0.arch.pool.ntp.org'
   when 'Gentoo'
     line = '0.gentoo.pool.ntp.org'
   end

--- a/spec/acceptance/ntp_config_spec.rb
+++ b/spec/acceptance/ntp_config_spec.rb
@@ -6,7 +6,12 @@ when 'FreeBSD'
 when 'Debian'
   line = '0.debian.pool.ntp.org iburst'
 when 'RedHat'
-  line = '0.centos.pool.ntp.org'
+  case fact('operatingsystem')
+  when 'Fedora'
+    line = '0.fedora.pool.ntp.org'
+  else
+    line = '0.centos.pool.ntp.org'
+  end
 when 'Suse'
   line = '0.opensuse.pool.ntp.org'
 when 'Gentoo'

--- a/spec/acceptance/ntp_install_spec.rb
+++ b/spec/acceptance/ntp_install_spec.rb
@@ -15,7 +15,7 @@ when 'Linux'
 when 'AIX'
   packagename = 'bos.net.tcp.client'
 when 'Solaris'
-  case fact('operatingsystemrelease')
+  case fact('kernelrelease')
   when '5.10'
     packagename = ['SUNWntpr','SUNWntpu']
   when '5.11'

--- a/spec/acceptance/ntp_parameters_spec.rb
+++ b/spec/acceptance/ntp_parameters_spec.rb
@@ -15,7 +15,7 @@ when 'Linux'
 when 'AIX'
   packagename = 'bos.net.tcp.client'
 when 'Solaris'
-  case fact('operatingsystemrelease')
+  case fact('kernelrelease')
   when '5.10'
     packagename = ['SUNWntpr','SUNWntpu']
   when '5.11'

--- a/spec/acceptance/ntp_parameters_spec.rb
+++ b/spec/acceptance/ntp_parameters_spec.rb
@@ -181,4 +181,16 @@ describe "ntp class:", :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamily'
     end
   end
 
+  describe 'udlc_stratum' do
+    it 'sets the stratum value when using udlc' do
+      pp = "class { 'ntp': udlc => true, udlc_stratum => 10 }"
+      apply_manifest(pp, :catch_failures => true)
+    end
+
+    describe file("#{config}") do
+      it { should be_file }
+      its(:content) { should match 'stratum 10' }
+    end
+  end
+
 end

--- a/spec/acceptance/ntp_parameters_spec.rb
+++ b/spec/acceptance/ntp_parameters_spec.rb
@@ -139,33 +139,33 @@ describe "ntp class:", :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamily'
     end
   end
 
-  describe 'panic => false' do
-    it 'enables the tinker panic setting' do
-      pp = <<-EOS
-      class { 'ntp':
-        panic => false,
-      }
-      EOS
-      apply_manifest(pp, :catch_failures => true)
-    end
-
-    describe file("#{config}") do
-      its(:content) { should match 'tinker panic' }
-    end
-  end
-
-  describe 'panic => true' do
+  describe 'panic => 0' do
     it 'disables the tinker panic setting' do
       pp = <<-EOS
       class { 'ntp':
-        panic => true,
+        panic => 0,
       }
       EOS
       apply_manifest(pp, :catch_failures => true)
     end
 
     describe file("#{config}") do
-      its(:content) { should_not match 'tinker panic 0' }
+      its(:content) { should match 'tinker panic 0' }
+    end
+  end
+
+  describe 'panic => 1' do
+    it 'enables the tinker panic setting' do
+      pp = <<-EOS
+      class { 'ntp':
+        panic => 1,
+      }
+      EOS
+      apply_manifest(pp, :catch_failures => true)
+    end
+
+    describe file("#{config}") do
+      its(:content) { should match 'tinker panic 1' }
     end
   end
 

--- a/spec/classes/ntp_spec.rb
+++ b/spec/classes/ntp_spec.rb
@@ -291,6 +291,33 @@ describe 'ntp' do
             end
           end
         end
+
+        describe 'peers' do
+          context 'when empty' do
+            let(:params) do
+              {
+                :peers => []
+              }
+            end
+
+            it 'should not contain a peer line' do
+              should contain_file('/etc/ntp.conf').without_content(/^peer/)
+            end
+          end
+
+          context 'set' do
+            let(:params) do
+              {
+                :peers => ['foo', 'bar'],
+              }
+            end
+
+            it 'should contain the peer lines' do
+              should contain_file('/etc/ntp.conf').with_content(/peer foo/)
+              should contain_file('/etc/ntp.conf').with_content(/peer bar/)
+            end
+          end
+        end
       end
     end
 

--- a/spec/classes/ntp_spec.rb
+++ b/spec/classes/ntp_spec.rb
@@ -411,8 +411,8 @@ describe 'ntp' do
         })
         end
 
-        it { expect{ subject }.to raise_error(
-          /^The ntp module is not supported on an unsupported based system./
+        it { expect{ catalogue }.to raise_error(
+          /The ntp module is not supported on an unsupported based system./
         )}
       end
     end

--- a/spec/classes/ntp_spec.rb
+++ b/spec/classes/ntp_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'ntp' do
   let(:facts) {{ :is_virtual => 'false' }}
 
-  ['Debian', 'RedHat','Suse', 'FreeBSD', 'Archlinux', 'Gentoo', 'Gentoo (Facter < 1.7)'].each do |system|
+  ['Debian', 'RedHat', 'Fedora', 'Suse', 'FreeBSD', 'Archlinux', 'Gentoo', 'Gentoo (Facter < 1.7)'].each do |system|
     context "when on system #{system}" do
       if system == 'Gentoo (Facter < 1.7)'
         let :facts do
@@ -12,6 +12,10 @@ describe 'ntp' do
       elsif system == 'Suse'
         let :facts do
           super().merge({ :osfamily => system,:operatingsystem => 'SLES',:operatingsystemmajrelease => '11' })
+        end
+      elsif system == 'Fedora'
+        let :facts do
+          super().merge({ :osfamily => 'RedHat', :operatingsystem => system ,:operatingsystemmajrelease => '22' })
         end
       else
         let :facts do

--- a/spec/classes/ntp_spec.rb
+++ b/spec/classes/ntp_spec.rb
@@ -472,6 +472,32 @@ describe 'ntp' do
           end
         end
 
+        describe 'with parameter tos' do
+          context 'when set to true' do
+            let(:params) {{
+              :tos     => true,
+            }}
+
+            it 'should contain logfile setting' do
+              should contain_file('/etc/ntp.conf').with({
+              'content' => /^tos/,
+              })
+            end
+          end
+
+          context 'when set to false' do
+            let(:params) {{
+              :tos     => false,
+            }}
+
+            it 'should not contain a logfile line' do
+              should_not contain_file('/etc/ntp.conf').with({
+                'content' => /^tos/,
+              })
+            end
+          end
+        end
+
         describe 'peers' do
           context 'when empty' do
             let(:params) do

--- a/spec/classes/ntp_spec.rb
+++ b/spec/classes/ntp_spec.rb
@@ -637,9 +637,9 @@ describe 'ntp' do
         end
       end
 
-      describe "on osfamily Solaris and operatingsystemrelease 5.10" do
+      describe "on osfamily Solaris and kernelrelease 5.10" do
         let :facts do
-          super().merge({ :osfamily => 'Solaris', :operatingsystemrelease => '5.10' })
+          super().merge({ :osfamily => 'Solaris', :kernelrelease => '5.10' })
         end
 
         it 'uses the NTP pool servers by default' do
@@ -649,9 +649,9 @@ describe 'ntp' do
         end
       end
 
-      describe "on osfamily Solaris and operatingsystemrelease 5.11" do
+      describe "on osfamily Solaris and kernelrelease 5.11" do
         let :facts do
-          super().merge({ :osfamily => 'Solaris', :operatingsystemrelease => '5.11' })
+          super().merge({ :osfamily => 'Solaris', :kernelrelease => '5.11' })
         end
 
         it 'uses the NTP pool servers by default' do

--- a/spec/classes/ntp_spec.rb
+++ b/spec/classes/ntp_spec.rb
@@ -502,7 +502,7 @@ describe 'ntp' do
               :tos     => true,
             }}
 
-            it 'should contain logfile setting' do
+            it 'should contain tos setting' do
               should contain_file('/etc/ntp.conf').with({
               'content' => /^tos/,
               })
@@ -514,7 +514,7 @@ describe 'ntp' do
               :tos     => false,
             }}
 
-            it 'should not contain a logfile line' do
+            it 'should not contain tos setting' do
               should_not contain_file('/etc/ntp.conf').with({
                 'content' => /^tos/,
               })

--- a/spec/classes/ntp_spec.rb
+++ b/spec/classes/ntp_spec.rb
@@ -576,9 +576,9 @@ describe 'ntp' do
           super().merge({ :osfamily => 'ArchLinux' })
         end
 
-        it 'uses the NTP pool servers by default' do
+        it 'uses the ArchLinux NTP servers by default' do
           should contain_file('/etc/ntp.conf').with({
-            'content' => /server \d.pool.ntp.org/,
+            'content' => /server \d.arch.pool.ntp.org/,
           })
         end
       end

--- a/spec/classes/ntp_spec.rb
+++ b/spec/classes/ntp_spec.rb
@@ -155,6 +155,30 @@ describe 'ntp' do
             end
           end
         end
+        describe 'with parameter disable_kernel' do
+          context 'when set to true' do
+            let(:params) {{
+              :disable_kernel => true,
+            }}
+
+            it 'should contain disable kernel setting' do
+              should contain_file('/etc/ntp.conf').with({
+              'content' => /^disable kernel\n/,
+              })
+            end
+          end
+          context 'when set to false' do
+            let(:params) {{
+              :disable_kernel => false,
+            }}
+
+            it 'should not contain disable kernel setting' do
+              should_not contain_file('/etc/ntp.conf').with({
+              'content' => /^disable kernel\n/,
+              })
+            end
+          end
+        end
         describe 'with parameter broadcastclient' do
           context 'when set to true' do
             let(:params) {{

--- a/spec/classes/ntp_spec.rb
+++ b/spec/classes/ntp_spec.rb
@@ -414,6 +414,33 @@ describe 'ntp' do
           end
         end
 
+        describe 'with parameter leapfile' do
+          context 'when set to true' do
+            let(:params) {{
+              :servers => ['a', 'b', 'c', 'd'],
+              :leapfile => '/etc/leap-seconds.3629404800',
+            }}
+
+            it 'should contain leapfile setting' do
+              should contain_file('/etc/ntp.conf').with({
+              'content' => /^leapfile \/etc\/leap-seconds\.3629404800\n/,
+              })
+            end
+          end
+
+          context 'when set to false' do
+            let(:params) {{
+              :servers => ['a', 'b', 'c', 'd'],
+            }}
+
+            it 'should not contain a leapfile line' do
+              should_not contain_file('/etc/ntp.conf').with({
+                'content' => /leapfile /,
+              })
+            end
+          end
+        end
+
         describe 'with parameter logfile' do
           context 'when set to true' do
             let(:params) {{

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -20,7 +20,7 @@ unless ENV['RS_PROVISION'] == 'no' or ENV['BEAKER_provision'] == 'no'
     on host, "mkdir -p #{host['distmoduledir']}"
     if host['platform'] =~ /sles-12/i || host['platform'] =~ /solaris-11/i
       apply_manifest_on(host, 'package{"git":}')
-      on host, 'git clone -b 4.3.x https://github.com/puppetlabs/puppetlabs-stdlib /etc/puppetlabs/puppet/modules/stdlib'
+      on host, 'git clone -b 4.6.x https://github.com/puppetlabs/puppetlabs-stdlib /etc/puppetlabs/puppet/modules/stdlib'
     else
       on host, puppet('module install puppetlabs-stdlib'), {:acceptable_exit_codes => [0, 1]}
     end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -5,7 +5,10 @@ UNSUPPORTED_PLATFORMS = ['windows', 'Darwin']
 unless ENV['RS_PROVISION'] == 'no' or ENV['BEAKER_provision'] == 'no'
   # This will install the latest available package on el and deb based
   # systems fail on windows and osx, and install via gem on other *nixes
-  foss_opts = {:default_action => 'gem_install'}
+  foss_opts = {
+    :default_action => 'gem_install',
+    :version        => (ENV['PUPPET_VERSION'] || '3.8.1'),
+  }
 
   if default.is_pe?; then
     install_pe;

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -26,12 +26,12 @@ unless ENV['RS_PROVISION'] == 'no' or ENV['BEAKER_provision'] == 'no'
       on host, puppet('module install puppetlabs-stdlib')
     end
 
-    #Need to disable update of ntp servers from DHCP, as subsequent restart of ntp causes test failures
-    if fact('osfamily') == 'Debian'
-      shell('[[ -f /etc/dhcp/dhclient-exit-hooks.d/ntp ]] && rm /etc/dhcp/dhcp-exit-hooks.d/ntp', { :acceptable_exit_codes => [0, 1] })
-      shell('[[ -f /etc/dhcp3/dhclient-exit-hooks.d/ntp ]] && rm /etc/dhcp3/dhcp-exit-hooks.d/ntp', { :acceptable_exit_codes => [0, 1] })
-    elsif fact('osfamily') == 'RedHat'
-      shell('echo "PEERNTP=no" >> /etc/sysconfig/network', { :acceptable_exit_codes => [0, 1]})
+    # Need to disable update of ntp servers from DHCP, as subsequent restart of ntp causes test failures
+    if fact_on(host, 'osfamily') == 'Debian'
+      on host, 'dpkg-divert --divert /etc/dhcp-ntp.bak --local --rename --add /etc/dhcp/dhclient-exit-hooks.d/ntp'
+      on host, 'dpkg-divert --divert /etc/dhcp3-ntp.bak --local --rename --add /etc/dhcp3/dhclient-exit-hooks.d/ntp'
+    elsif fact_on(host, 'osfamily') == 'RedHat'
+      on host, 'echo "PEERNTP=no" >> /etc/sysconfig/network'
     end
   end
 end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -5,7 +5,7 @@ UNSUPPORTED_PLATFORMS = ['windows', 'Darwin']
 
 unless ENV['RS_PROVISION'] == 'no' or ENV['BEAKER_provision'] == 'no'
 
-  run_puppet_installer
+  run_puppet_install_helper
 
   hosts.each do |host|
     if host['platform'] =~ /sles-12/i || host['platform'] =~ /solaris-11/i

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -25,9 +25,12 @@ unless ENV['RS_PROVISION'] == 'no' or ENV['BEAKER_provision'] == 'no'
       on host, puppet('module install puppetlabs-stdlib'), {:acceptable_exit_codes => [0, 1]}
     end
 
+    #Need to disable update of ntp servers from DHCP, as subsequent restart of ntp causes test failures
     if fact('osfamily') == 'Debian'
       shell('[[ -f /etc/dhcp/dhclient-exit-hooks.d/ntp ]] && rm /etc/dhcp/dhcp-exit-hooks.d/ntp', { :acceptable_exit_codes => [0, 1] })
       shell('[[ -f /etc/dhcp3/dhclient-exit-hooks.d/ntp ]] && rm /etc/dhcp3/dhcp-exit-hooks.d/ntp', { :acceptable_exit_codes => [0, 1] })
+    elsif fact('osfamily') == 'RedHat'
+      shell('echo "PEERNTP=no" >> /etc/sysconfig/network', { :acceptable_exit_codes => [0, 1]})
     end
   end
 end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -24,6 +24,11 @@ unless ENV['RS_PROVISION'] == 'no' or ENV['BEAKER_provision'] == 'no'
     else
       on host, puppet('module install puppetlabs-stdlib'), {:acceptable_exit_codes => [0, 1]}
     end
+
+    if fact('osfamily') == 'Debian'
+      shell('[[ -f /etc/dhcp/dhclient-exit-hooks.d/ntp ]] && rm /etc/dhcp/dhcp-exit-hooks.d/ntp', { :acceptable_exit_codes => [0, 1] })
+      shell('[[ -f /etc/dhcp3/dhclient-exit-hooks.d/ntp ]] && rm /etc/dhcp3/dhcp-exit-hooks.d/ntp', { :acceptable_exit_codes => [0, 1] })
+    end
   end
 end
 

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,26 +1,13 @@
 require 'beaker-rspec'
+require 'beaker/puppet_install_helper'
 
 UNSUPPORTED_PLATFORMS = ['windows', 'Darwin']
 
 unless ENV['RS_PROVISION'] == 'no' or ENV['BEAKER_provision'] == 'no'
-  # This will install the latest available package on el and deb based
-  # systems fail on windows and osx, and install via gem on other *nixes
-  foss_opts = {
-    :default_action => 'gem_install',
-    :version        => (ENV['PUPPET_VERSION'] || '3.8.1'),
-  }
 
-  if default.is_pe?; then
-    install_pe;
-  else
-    install_puppet(foss_opts);
-  end
+  run_puppet_installer
 
   hosts.each do |host|
-    unless host.is_pe?
-      on host, "/bin/echo '' > #{host['hieraconf']}"
-    end
-    on host, "mkdir -p #{host['distmoduledir']}"
     if host['platform'] =~ /sles-12/i || host['platform'] =~ /solaris-11/i
       apply_manifest_on(host, 'package{"git":}')
       on host, 'git clone -b 4.6.x https://github.com/puppetlabs/puppetlabs-stdlib /etc/puppetlabs/puppet/modules/stdlib'

--- a/templates/ntp.conf.erb
+++ b/templates/ntp.conf.erb
@@ -90,3 +90,8 @@ fudge <%= entry %>
 # Leapfile
 leapfile <%= @leapfile %>
 <% end -%>
+
+<% if @tos == true -%>
+tos <% if @minclock -%> minclock <%= @tos_minclock %><% end %><% if @tos_minsane -%> minsane <%= @tos_minsane %><% end %><% if @tos_floor -%> floor <%= @tos_floor %><% end %><% if @tos_ceiling -%> ceiling <%= @tos_ceiling %><% end %><% if @tos_cohort -%> cohort <%= @tos_cohort %><% end %>
+<% end %>
+

--- a/templates/ntp.conf.erb
+++ b/templates/ntp.conf.erb
@@ -42,7 +42,7 @@ server <%= server %><% if @iburst_enable == true -%> iburst<% end %><% if @prefe
 # Undisciplined Local Clock. This is a fake driver intended for backup
 # and when no outside source of synchronized time is available.
 server   127.127.1.0
-fudge    127.127.1.0 stratum 10
+fudge    127.127.1.0 stratum <%= @udlc_stratum %>
 restrict 127.127.1.0
 <% end -%>
 

--- a/templates/ntp.conf.erb
+++ b/templates/ntp.conf.erb
@@ -85,3 +85,8 @@ controlkey <%= @keys_controlkey %>
 <% [@fudge].flatten.each do |entry| -%>
 fudge <%= entry %>
 <% end -%>
+
+<% unless @leapfile.nil? -%>
+# Leapfile
+leapfile <%= @leapfile %>
+<% end -%>

--- a/templates/ntp.conf.erb
+++ b/templates/ntp.conf.erb
@@ -54,6 +54,13 @@ driftfile <%= @driftfile %>
 logfile <%= @logfile %>
 <% end -%>
 
+<% unless @peers.empty? -%>
+# Peers
+<% [@peers].flatten.each do |peer| -%>
+peer <%= peer %>
+<% end -%>
+<% end -%>
+
 <% if @keys_enable -%>
 keys <%= @keys_file %>
 <% unless @keys_trusted.empty? -%>

--- a/templates/ntp.conf.erb
+++ b/templates/ntp.conf.erb
@@ -78,7 +78,7 @@ keys <%= @keys_file %>
 trustedkey <%= @keys_trusted.join(' ') %>
 <% end -%>
 <% if @keys_requestkey != '' -%>
-requestkey <%= @keys_requestkey %>
+  requestkey <%= @keys_requestkey %>
 <% end -%>
 <% if @keys_controlkey != '' -%>
 controlkey <%= @keys_controlkey %>

--- a/templates/ntp.conf.erb
+++ b/templates/ntp.conf.erb
@@ -14,6 +14,9 @@ disable monitor
 <% if @disable_auth == true -%>
 disable auth
 <% end -%>
+<% if @disable_kernel == true -%>
+disable kernel
+<% end -%>
 
 <% if @restrict != [] -%>
 # Permit time synchronization with our time source, but do not

--- a/templates/ntp.conf.erb
+++ b/templates/ntp.conf.erb
@@ -95,6 +95,6 @@ leapfile <%= @leapfile %>
 <% end -%>
 
 <% if @tos == true -%>
-tos <% if @minclock -%> minclock <%= @tos_minclock %><% end %><% if @tos_minsane -%> minsane <%= @tos_minsane %><% end %><% if @tos_floor -%> floor <%= @tos_floor %><% end %><% if @tos_ceiling -%> ceiling <%= @tos_ceiling %><% end %><% if @tos_cohort -%> cohort <%= @tos_cohort %><% end %>
+tos <% if @tos_minclock -%> minclock <%= @tos_minclock %><% end %><% if @tos_minsane -%> minsane <%= @tos_minsane %><% end %><% if @tos_floor -%> floor <%= @tos_floor %><% end %><% if @tos_ceiling -%> ceiling <%= @tos_ceiling %><% end %><% if @tos_cohort -%> cohort <%= @tos_cohort %><% end %>
 <% end %>
 

--- a/templates/ntp.conf.erb
+++ b/templates/ntp.conf.erb
@@ -1,9 +1,11 @@
 # ntp.conf: Managed by puppet.
 #
-<% if @panic == false -%>
-# Keep ntpd from panicking in the event of a large clock skew
-# when a VM guest is suspended and resumed.
-tinker panic 0
+<% if @tinker == true and (@panic or @stepout) -%>
+# Enable next tinker options:
+# panic - keep ntpd from panicking in the event of a large clock skew
+# when a VM guest is suspended and resumed;
+# stepout - allow ntpd change offset faster
+tinker<% if @panic -%> panic <%= @panic %><% end %><% if @stepout -%> stepout <%= @stepout %><% end %>
 <% end -%>
 
 <% if @disable_monitor == true -%>
@@ -34,8 +36,14 @@ interface listen <%= interface %>
 broadcastclient
 <% end -%>
 
+# Set up servers for ntpd with next options:
+# server - IP address or DNS name of upstream NTP server
+# iburst - allow send sync packages faster if upstream unavailable
+# prefer - select preferrable server
+# minpoll - set minimal update frequency
+# maxpoll - set maximal update frequency
 <% [@servers].flatten.each do |server| -%>
-server <%= server %><% if @iburst_enable == true -%> iburst<% end %><% if @preferred_servers.include?(server) -%> prefer<% end %>
+server <%= server %><% if @iburst_enable == true -%> iburst<% end %><% if @preferred_servers.include?(server) -%> prefer<% end %><% if @minpoll -%> minpoll <%= @minpoll %><% end %><% if @maxpoll -%> maxpoll <%= @maxpoll %><% end %>
 <% end -%>
 
 <% if @udlc -%>

--- a/templates/ntp.conf.erb
+++ b/templates/ntp.conf.erb
@@ -67,3 +67,6 @@ controlkey <%= @keys_controlkey %>
 <% end -%>
 
 <% end -%>
+<% [@fudge].flatten.each do |entry| -%>
+fudge <%= entry %>
+<% end -%>


### PR DESCRIPTION
We are using the Amazon Linux for a few of our servers, and needed to add it like so (no osfamily, and ::operatingsystem of Amazon) to params.pp (with the same params as RedHat). 