### PR TITLE
Update Arch Linux defaults

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -158,7 +158,7 @@ class ntp::params {
     'Archlinux': {
       $config          = $default_config
       $keys_file       = $default_keys_file
-      $driftfile       = $default_driftfile
+      $driftfile       = '/var/lib/ntp/ntp.drift'
       $package_name    = $default_package_name
       $service_name    = $default_service_name
       $restrict        = [
@@ -169,9 +169,10 @@ class ntp::params {
       ]
       $iburst_enable   = false
       $servers         = [
-        '0.pool.ntp.org',
-        '1.pool.ntp.org',
-        '2.pool.ntp.org',
+        '0.arch.pool.ntp.org',
+        '1.arch.pool.ntp.org',
+        '2.arch.pool.ntp.org',
+        '3.arch.pool.ntp.org',
       ]
       $maxpoll         = undef
     }

--- a/spec/acceptance/ntp_config_spec.rb
+++ b/spec/acceptance/ntp_config_spec.rb
@@ -14,7 +14,7 @@ when 'Gentoo'
 when 'Linux'
   case fact('operatingsystem')
   when 'ArchLinux'
-    line = '0.pool.ntp.org'
+    line = '0.arch.pool.ntp.org'
   when 'Gentoo'
     line = '0.gentoo.pool.ntp.org'
   end

--- a/spec/classes/ntp_spec.rb
+++ b/spec/classes/ntp_spec.rb
@@ -576,9 +576,9 @@ describe 'ntp' do
           super().merge({ :osfamily => 'ArchLinux' })
         end
 
-        it 'uses the NTP pool servers by default' do
+        it 'uses the ArchLinux NTP servers by default' do
           should contain_file('/etc/ntp.conf').with({
-            'content' => /server \d.pool.ntp.org/,
+            'content' => /server \d.arch.pool.ntp.org/,
           })
         end
       end


### PR DESCRIPTION
Arch Linux has its own pool [1], it also ships a different default
drift file [2].

[1] https://bugs.archlinux.org/task/41700
[2] https://projects.archlinux.org/svntogit/packages.git/tree/trunk?h=packages/ntp