### PR TITLE
(MODULES-2087) fix debian default config

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -72,7 +72,7 @@ class ntp::params {
       $driftfile       = $default_driftfile
       $package_name    = $default_package_name
       $restrict        = [
-        '-4 kod nomodify notrap nopeer noquery',
+        '-4 default kod nomodify notrap nopeer noquery',
         '-6 default kod nomodify notrap nopeer noquery',
         '127.0.0.1',
         '::1',


### PR DESCRIPTION
ntpd reports syntax errors on wheezy and jessie with the original
value, presumably creating a subtly broken config.