### PR TITLE
- add Solaris 12 support

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -291,7 +291,7 @@ Specifies the stratum the server should operate at when using the undisciplined 
 
 ##Limitations
 
-This module has been tested on [all PE-supported platforms](https://forge.puppetlabs.com/supported#compat-matrix), and no issues have been identified.
+This module has been tested on [all PE-supported platforms](https://forge.puppetlabs.com/supported#compat-matrix), and no issues have been identified. Additionally, it is tested (but not supported) on Solaris 12.
 
 ##Development
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -181,7 +181,8 @@ class ntp::params {
       $keys_file     = '/etc/inet/ntp.keys'
       $package_name  = $::operatingsystemrelease ? {
         /^(5\.10|10|10_u\d+)$/ => [ 'SUNWntpr', 'SUNWntpu' ],
-        /^(5\.11|11|11\.\d+)$/ => [ 'service/network/ntp' ]
+        /^(5\.11|11|11\.\d+)$/ => [ 'service/network/ntp' ],
+        /^(5\.12|12|12\.\d+)$/ => [ 'service/network/ntp' ]
       }
       $restrict      = [
         'default kod nomodify notrap nopeer noquery',

--- a/metadata.json
+++ b/metadata.json
@@ -66,7 +66,8 @@
     {
       "operatingsystem": "Solaris",
       "operatingsystemrelease": [
-        "11"
+        "11",
+        "12"
       ]
     },
     {


### PR DESCRIPTION
Add support for Solaris 12.  Solaris 12's package names match Solaris 11 so it's fairly straight-forward.