### PR TITLE
Ensure the log file is created before the service is started/configured.

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -21,10 +21,10 @@ class ntp::config inherits ntp {
 
   if $ntp::logfile {
     file { $ntp::logfile:
-      ensure  => 'file',
-      owner   => 'ntp',
-      group   => 'ntp',
-      mode    => '0664',
+      ensure => 'file',
+      owner  => 'ntp',
+      group  => 'ntp',
+      mode   => '0664',
     }
   }
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -19,4 +19,13 @@ class ntp::config inherits ntp {
     content => template($ntp::config_template),
   }
 
+  if $ntp::logfile {
+    file { $ntp::logfile:
+      ensure  => 'file',
+      owner   => 'ntp',
+      group   => 'ntp',
+      mode    => '0664',
+    }
+  }
+
 }


### PR DESCRIPTION
When installing the package, create the log file.
