### PR TITLE
MODULES-2210 Add TOS Parameter

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -277,6 +277,30 @@ Tells Puppet what NTP service to manage. Valid options: string. Default value: v
 
 Tells puppet to change stepout. Applies only if `tinker` value is 'true'. Valid options: unsigned shortint digit. Default value: undef.
 
+####`tos`
+
+Tells Puppet to enable tos options. Valid options: 'true' of 'false'. Default value: 'false'
+
+####`tos_minclock`
+
+Specifies the minclock tos option. Valid options: numeric. Default value: 3
+
+####`tos_minsane`
+
+Specifies the minsane tos option. Valid options: numeric. Default value: 1
+
+####`tos_floor`
+
+Specifies the floor tos option. Valid options: numeric. Default value: 1
+
+####`tos_ceiling`
+
+Specifies the ceiling tos option. Valid options: numeric. Default value: 15
+
+####`tos_cohort`
+
+Specifies the cohort tos option. Valid options: '0' or '1'. Default value: 0
+
 ####`tinker`
 
 Tells Puppet to enable tinker options. Valid options: 'true' of 'false'. Default value: 'false'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -32,6 +32,12 @@ class ntp (
   $service_name      = $ntp::params::service_name,
   $stepout           = $ntp::params::stepout,
   $tinker            = $ntp::params::tinker,
+  $tos               = $ntp::params::tos,
+  $tos_minclock      = $ntp::params::tos_minclock,
+  $tos_minsane       = $ntp::params::tos_minsane,
+  $tos_floor         = $ntp::params::tos_floor,
+  $tos_ceiling       = $ntp::params::tos_ceiling,
+  $tos_cohort        = $ntp::params::tos_cohort,
   $udlc              = $ntp::params::udlc,
   $udlc_stratum      = $ntp::params::udlc_stratum,
 ) inherits ntp::params {
@@ -66,6 +72,12 @@ class ntp (
   validate_string($service_name)
   if $stepout { validate_numeric($stepout, 65535, 0) }
   validate_bool($tinker)
+  validate_bool($tos)
+  if $tos_minclock { validate_numeric($tos_minclock) }
+  if $tos_minsane { validate_numeric($tos_minsane) }
+  if $tos_floor { validate_numeric($tos_floor) }
+  if $tos_ceiling { validate_numeric($tos_ceiling) }
+  if $tos_cohort { validate_re($tos_cohort, '^[0|1]$', "Must be 0 or 1, got: ${tos_cohort}") }
   validate_bool($udlc)
   validate_array($peers)
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -21,6 +21,12 @@ class ntp::params {
   $interfaces        = []
   $disable_auth      = false
   $broadcastclient   = false
+  $tos               = false
+  $tos_minclock      = '3'
+  $tos_minsane       = '1'
+  $tos_floor         = '1'
+  $tos_ceiling       = '15'
+  $tos_cohort        = '0'
 
   # Allow a list of fudge options
   $fudge             = []

--- a/spec/classes/ntp_spec.rb
+++ b/spec/classes/ntp_spec.rb
@@ -472,6 +472,32 @@ describe 'ntp' do
           end
         end
 
+        describe 'with parameter tos' do
+          context 'when set to true' do
+            let(:params) {{
+              :tos     => true,
+            }}
+
+            it 'should contain logfile setting' do
+              should contain_file('/etc/ntp.conf').with({
+              'content' => /^tos/,
+              })
+            end
+          end
+
+          context 'when set to false' do
+            let(:params) {{
+              :tos     => false,
+            }}
+
+            it 'should not contain a logfile line' do
+              should_not contain_file('/etc/ntp.conf').with({
+                'content' => /^tos/,
+              })
+            end
+          end
+        end
+
         describe 'peers' do
           context 'when empty' do
             let(:params) do

--- a/templates/ntp.conf.erb
+++ b/templates/ntp.conf.erb
@@ -90,3 +90,8 @@ fudge <%= entry %>
 # Leapfile
 leapfile <%= @leapfile %>
 <% end -%>
+
+<% if @tos == true -%>
+tos <% if @minclock -%> minclock <%= @tos_minclock %><% end %><% if @tos_minsane -%> minsane <%= @tos_minsane %><% end %><% if @tos_floor -%> floor <%= @tos_floor %><% end %><% if @tos_ceiling -%> ceiling <%= @tos_ceiling %><% end %><% if @tos_cohort -%> cohort <%= @tos_cohort %><% end %>
+<% end %>
+


### PR DESCRIPTION
```
Manycast Options
     tos [ceiling ceiling | cohort { 0 | 1 } | floor floor | minclock minclock
	     | minsane minsane]
	     This command affects the clock selection and clustering algo-
	     rithms.  It can be	used to	select the quality and quantity	of
	     peers used	to synchronize the system clock	and is most useful in
	     manycast mode.  The variables operate as follows:
```