### PR TITLE
Fix CI for PE.next

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -130,17 +130,34 @@ class ntp::params {
       }
     }
     'Suse': {
-      if $::operatingsystem == 'SLES' and $::operatingsystemmajrelease == '12'
-      {
-        $service_name  = 'ntpd'
-        $keys_file     = '/etc/ntp.keys'
-      } else{
+      if $::operatingsystem == 'SLES' {
+        case $::operatingsystemmajrelease {
+          '10': {
+            $service_name  = 'ntp'
+            $keys_file     = '/etc/ntp.keys'
+            $package_name  = [ 'xntp' ]
+          }
+          '11': {
+            $service_name  = 'ntp'
+            $keys_file     = $default_keys_file
+            $package_name  = $default_package_name
+          }
+          '12': {
+            $service_name  = 'ntpd'
+            $keys_file     = '/etc/ntp.keys'
+            $package_name  = $default_package_name
+          }
+          default: {
+            fail("The ${module_name} module is not supported on an ${::operatingsystem} ${::operatingsystemmajrelease} distribution.")
+          }
+        }
+      } else {
         $service_name  = 'ntp'
         $keys_file     = $default_keys_file
+        $package_name  = $default_package_name
       }
       $config          = $default_config
       $driftfile       = '/var/lib/ntp/drift/ntp.drift'
-      $package_name    = $default_package_name
       $restrict        = [
         'default kod nomodify notrap nopeer noquery',
         '-6 default kod nomodify notrap nopeer noquery',

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -26,12 +26,12 @@ unless ENV['RS_PROVISION'] == 'no' or ENV['BEAKER_provision'] == 'no'
       on host, puppet('module install puppetlabs-stdlib')
     end
 
-    #Need to disable update of ntp servers from DHCP, as subsequent restart of ntp causes test failures
-    if fact('osfamily') == 'Debian'
-      shell('[[ -f /etc/dhcp/dhclient-exit-hooks.d/ntp ]] && rm /etc/dhcp/dhcp-exit-hooks.d/ntp', { :acceptable_exit_codes => [0, 1] })
-      shell('[[ -f /etc/dhcp3/dhclient-exit-hooks.d/ntp ]] && rm /etc/dhcp3/dhcp-exit-hooks.d/ntp', { :acceptable_exit_codes => [0, 1] })
-    elsif fact('osfamily') == 'RedHat'
-      shell('echo "PEERNTP=no" >> /etc/sysconfig/network', { :acceptable_exit_codes => [0, 1]})
+    # Need to disable update of ntp servers from DHCP, as subsequent restart of ntp causes test failures
+    if fact_on(host, 'osfamily') == 'Debian'
+      on host, 'dpkg-divert --divert /etc/dhcp-ntp.bak --local --rename --add /etc/dhcp/dhclient-exit-hooks.d/ntp'
+      on host, 'dpkg-divert --divert /etc/dhcp3-ntp.bak --local --rename --add /etc/dhcp3/dhclient-exit-hooks.d/ntp'
+    elsif fact_on(host, 'osfamily') == 'RedHat'
+      on host, 'echo "PEERNTP=no" >> /etc/sysconfig/network'
     end
   end
 end


### PR DESCRIPTION
I've run this branch manually through jenkins and it was green: https://jenkins-modules.puppetlabs.com/view/2.%20linux%20only/view/ntp/view/master/