### PR TITLE
fix for tos settings in ntp.conf template and spec file

### DIFF
--- a/spec/classes/ntp_spec.rb
+++ b/spec/classes/ntp_spec.rb
@@ -502,7 +502,7 @@ describe 'ntp' do
               :tos     => true,
             }}
 
-            it 'should contain logfile setting' do
+            it 'should contain tos setting' do
               should contain_file('/etc/ntp.conf').with({
               'content' => /^tos/,
               })
@@ -514,7 +514,7 @@ describe 'ntp' do
               :tos     => false,
             }}
 
-            it 'should not contain a logfile line' do
+            it 'should not contain tos setting' do
               should_not contain_file('/etc/ntp.conf').with({
                 'content' => /^tos/,
               })

--- a/templates/ntp.conf.erb
+++ b/templates/ntp.conf.erb
@@ -95,6 +95,6 @@ leapfile <%= @leapfile %>
 <% end -%>
 
 <% if @tos == true -%>
-tos <% if @minclock -%> minclock <%= @tos_minclock %><% end %><% if @tos_minsane -%> minsane <%= @tos_minsane %><% end %><% if @tos_floor -%> floor <%= @tos_floor %><% end %><% if @tos_ceiling -%> ceiling <%= @tos_ceiling %><% end %><% if @tos_cohort -%> cohort <%= @tos_cohort %><% end %>
+tos <% if @tos_minclock -%> minclock <%= @tos_minclock %><% end %><% if @tos_minsane -%> minsane <%= @tos_minsane %><% end %><% if @tos_floor -%> floor <%= @tos_floor %><% end %><% if @tos_ceiling -%> ceiling <%= @tos_ceiling %><% end %><% if @tos_cohort -%> cohort <%= @tos_cohort %><% end %>
 <% end %>
 


### PR DESCRIPTION
The newly added tos settings for the ntp.conf file do not work because of a typo in the ntp.conf.erb. if @minclock should be if @tos_minclock. 