### PR TITLE
Update Solaris support for newer Facter

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -229,7 +229,7 @@ class ntp::params {
       $config        = '/etc/inet/ntp.conf'
       $driftfile     = '/var/ntp/ntp.drift'
       $keys_file     = '/etc/inet/ntp.keys'
-      if $::operatingsystemrelease =~ /^(5\.10|10|10_u\d+)$/
+      if $::kernelrelease == '5.10'
       {
         # Solaris 10
         $package_name = [ 'SUNWntpr', 'SUNWntpu' ]

--- a/spec/acceptance/ntp_install_spec.rb
+++ b/spec/acceptance/ntp_install_spec.rb
@@ -15,7 +15,7 @@ when 'Linux'
 when 'AIX'
   packagename = 'bos.net.tcp.client'
 when 'Solaris'
-  case fact('operatingsystemrelease')
+  case fact('kernelrelease')
   when '5.10'
     packagename = ['SUNWntpr','SUNWntpu']
   when '5.11'

--- a/spec/acceptance/ntp_parameters_spec.rb
+++ b/spec/acceptance/ntp_parameters_spec.rb
@@ -15,7 +15,7 @@ when 'Linux'
 when 'AIX'
   packagename = 'bos.net.tcp.client'
 when 'Solaris'
-  case fact('operatingsystemrelease')
+  case fact('kernelrelease')
   when '5.10'
     packagename = ['SUNWntpr','SUNWntpu']
   when '5.11'

--- a/spec/classes/ntp_spec.rb
+++ b/spec/classes/ntp_spec.rb
@@ -637,9 +637,9 @@ describe 'ntp' do
         end
       end
 
-      describe "on osfamily Solaris and operatingsystemrelease 5.10" do
+      describe "on osfamily Solaris and kernelrelease 5.10" do
         let :facts do
-          super().merge({ :osfamily => 'Solaris', :operatingsystemrelease => '5.10' })
+          super().merge({ :osfamily => 'Solaris', :kernelrelease => '5.10' })
         end
 
         it 'uses the NTP pool servers by default' do
@@ -649,9 +649,9 @@ describe 'ntp' do
         end
       end
 
-      describe "on osfamily Solaris and operatingsystemrelease 5.11" do
+      describe "on osfamily Solaris and kernelrelease 5.11" do
         let :facts do
-          super().merge({ :osfamily => 'Solaris', :operatingsystemrelease => '5.11' })
+          super().merge({ :osfamily => 'Solaris', :kernelrelease => '5.11' })
         end
 
         it 'uses the NTP pool servers by default' do


### PR DESCRIPTION
Due to a change in behavior between Facter 1.x and 2.x, the
operatingsystemrelease fact is no longer a desireable determination
of Solaris release.  This work updates the module to use the
kernelrelease fact in place of operatingsystemrelease as it does not
change behavior and is likely a more accurate representation of the
version of Solaris being tested.