### PR TITLE
Adding ::operatingsystem Amazon for Facter < 1.7.0 (cloud-init installs 1.6.18)

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -307,6 +307,27 @@ class ntp::params {
           $maxpoll         = undef
           $disable_monitor = false
         }
+        'Amazon': {
+          $config          = $default_config
+          $keys_file       = $default_keys_file
+          $driftfile       = $default_driftfile
+          $package_name    = $default_package_name
+          $service_name    = $default_service_name
+          $restrict        = [
+            'default kod nomodify notrap nopeer noquery',
+            '-6 default kod nomodify notrap nopeer noquery',
+            '127.0.0.1',
+            '-6 ::1',
+          ]
+          $iburst_enable   = false
+          $servers         = [
+            '0.centos.pool.ntp.org',
+            '1.centos.pool.ntp.org',
+            '2.centos.pool.ntp.org',
+          ]
+          $maxpoll         = undef
+          $disable_monitor = false
+        }
         default: {
           fail("The ${module_name} module is not supported on an ${::operatingsystem} distribution.")
         }

--- a/metadata.json
+++ b/metadata.json
@@ -84,6 +84,15 @@
         "6.1",
         "7.1"
       ]
+    },
+    {
+      "operatingsystem": "Amazon",
+      "operatingsystemrelease": [
+        "2013.09",
+        "2014.03",
+        "2014.09",
+        "2015.03"
+      ]
     }
   ],
   "requirements": [
@@ -96,7 +105,7 @@
       "version_requirement": ">= 3.0.0 < 5.0.0"
     }
   ],
-  "description": "NTP Module for Debian, Ubuntu, CentOS, RHEL, OEL, Fedora, FreeBSD, ArchLinux and Gentoo.",
+  "description": "NTP Module for Debian, Ubuntu, CentOS, RHEL, OEL, Fedora, FreeBSD, ArchLinux, Amazon Linux and Gentoo.",
   "dependencies": [
     {"name":"puppetlabs/stdlib","version_requirement":">= 4.6.0 < 5.0.0"}
   ]


### PR DESCRIPTION
Having rebase issues, so re-forked and added the changes. Much easier.
For history - see https://github.com/puppetlabs/puppetlabs-ntp/pull/263