### PR TITLE
Convert license string to SPDX format

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,7 @@
   "version": "4.1.0",
   "author": "Puppet Labs",
   "summary": "Installs, configures, and manages the NTP service.",
-  "license": "Apache Version 2.0",
+  "license": "Apache-2.0",
   "source": "https://github.com/puppetlabs/puppetlabs-ntp",
   "project_page": "https://github.com/puppetlabs/puppetlabs-ntp",
   "issues_url": "https://tickets.puppetlabs.com/browse/MODULES",


### PR DESCRIPTION
I noticed there was a warning on the Puppet Forge metadata quality score about license formatting. It should follow the SPDX format.

https://docs.puppetlabs.com/puppet/latest/reference/modules_publishing.html#write-a-metadatajson-file
http://spdx.org/licenses/