### PR TITLE
Support the ntpsigndsocket parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2015-12-10 - Supported Release 4.1.0
+### Summary
+Added support for signing NTP packets
+
+#### Features
+- Added the `ntpsigndsocket` property 
+
 ## 2015-07-21 - Supported Release 4.1.0
 ### Summary
 This release updates metadata to support new version of puppet enterprise, as well as new features, bugfixes, and test improvements.

--- a/README.markdown
+++ b/README.markdown
@@ -225,6 +225,10 @@ Tells Puppet to use non-standard minimal poll interval of upstream servers. Vali
 
 Tells Puppet to use non-standard maximal poll interval of upstream servers. Valid options: 3 to 16. Default option: undef, except FreeBSD (on FreeBSD `maxpoll` set 9 by default).
 
+####`ntpsigndsocket`
+
+Tells NTP to sign packets using the socket in the ntpsigndsocket path. NTP must be configured to sign sockets for this to work.
+
 ####`package_ensure`
 
 Tells Puppet whether the NTP package should be installed, and what version. Valid options: 'present', 'latest', or a specific version number. Default value: 'present'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -44,6 +44,7 @@ class ntp (
   $tos_cohort        = $ntp::params::tos_cohort,
   $udlc              = $ntp::params::udlc,
   $udlc_stratum      = $ntp::params::udlc_stratum,
+  $ntpsigndsocket    = $ntp::params::ntpsigndsocket,
 ) inherits ntp::params {
 
   validate_bool($broadcastclient)
@@ -55,6 +56,7 @@ class ntp (
   validate_bool($disable_monitor)
   validate_absolute_path($driftfile)
   if $logfile { validate_absolute_path($logfile) }
+  if $ntpsigndsocket { validate_absolute_path($ntpsigndsocket) }
   if $leapfile { validate_absolute_path($leapfile) }
   validate_bool($iburst_enable)
   validate_bool($keys_enable)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -31,7 +31,7 @@ class ntp::params {
   $tos_ceiling       = '15'
   $tos_cohort        = '0'
   $disable_dhclient  = false
-  $signd_socket      = undef
+  $ntpsigndsocket    = undef
 
   # Allow a list of fudge options
   $fudge             = []

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -31,6 +31,7 @@ class ntp::params {
   $tos_ceiling       = '15'
   $tos_cohort        = '0'
   $disable_dhclient  = false
+  $signd_socket      = undef
 
   # Allow a list of fudge options
   $fudge             = []

--- a/spec/classes/ntp_spec.rb
+++ b/spec/classes/ntp_spec.rb
@@ -551,8 +551,8 @@ describe 'ntp' do
 
             it 'should contain ntpsigndsocket setting' do
               should contain_file('/etc/ntp.conf').with({
-                                                            'content' => /^ntpsigndsocket \/usr\/local\/samba\/var\/lib\/ntp_signd\n/,
-                                                        })
+                'content' => /^ntpsigndsocket \/usr\/local\/samba\/var\/lib\/ntp_signd\n/,
+              })
             end
           end
 
@@ -563,8 +563,8 @@ describe 'ntp' do
 
             it 'should not contain a ntpsigndsocket line' do
               should_not contain_file('/etc/ntp.conf').with({
-                                                                'content' => /ntpsigndsocket /,
-                                                            })
+                'content' => /ntpsigndsocket /,
+              })
             end
           end
         end

--- a/spec/classes/ntp_spec.rb
+++ b/spec/classes/ntp_spec.rb
@@ -542,6 +542,33 @@ describe 'ntp' do
           end
         end
 
+        describe 'with parameter ntpsigndsocket' do
+          context 'when set to true' do
+            let(:params) {{
+                :servers => ['a', 'b', 'c', 'd'],
+                :ntpsigndsocket => '/usr/local/samba/var/lib/ntp_signd',
+            }}
+
+            it 'should contain ntpsigndsocket setting' do
+              should contain_file('/etc/ntp.conf').with({
+                                                            'content' => /^ntpsigndsocket \/usr\/local\/samba\/var\/lib\/ntp_signd\n/,
+                                                        })
+            end
+          end
+
+          context 'when set to false' do
+            let(:params) {{
+                :servers => ['a', 'b', 'c', 'd'],
+            }}
+
+            it 'should not contain a ntpsigndsocket line' do
+              should_not contain_file('/etc/ntp.conf').with({
+                                                                'content' => /ntpsigndsocket /,
+                                                            })
+            end
+          end
+        end
+
         describe 'with parameter tos' do
           context 'when set to true' do
             let(:params) {{

--- a/spec/classes/ntp_spec.rb
+++ b/spec/classes/ntp_spec.rb
@@ -551,7 +551,7 @@ describe 'ntp' do
 
             it 'should contain ntpsigndsocket setting' do
               should contain_file('/etc/ntp.conf').with({
-                'content' => /^ntpsigndsocket \/usr\/local\/samba\/var\/lib\/ntp_signd\n/,
+                'content' => %r(^ntpsigndsocket /usr/local/samba/var/lib/ntp_signd\n),
               })
             end
           end

--- a/templates/ntp.conf.erb
+++ b/templates/ntp.conf.erb
@@ -65,9 +65,9 @@ driftfile <%= @driftfile %>
 logfile <%= @logfile %>
 <% end -%>
 
-<% unless @signd_socket.nil? -%>
+<% unless @ntpsigndsocket.nil? -%>
 # Enable signed packets
-ntpsigndsocket <%= @signd_socket %>
+ntpsigndsocket <%= @ntpsigndsocket %>
 <% end -%>
 
 <% unless @peers.empty? -%>

--- a/templates/ntp.conf.erb
+++ b/templates/ntp.conf.erb
@@ -65,6 +65,11 @@ driftfile <%= @driftfile %>
 logfile <%= @logfile %>
 <% end -%>
 
+<% unless @signd_socket.nil? -%>
+# Enable signed packets
+ntpsigndsocket <%= @signd_socket %>
+<% end -%>
+
 <% unless @peers.empty? -%>
 # Peers
 <% [@peers].flatten.each do |peer| -%>


### PR DESCRIPTION
Several of my host, specifically Samba host require the NTP service to be signed. I have to compile the NTP binaries to support signing, but would like to include the ntpsigndsocket variable in the npt.conf file.

This change request enables the parameter.