### PR TITLE
Add parameter for interfaces to ignore

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -190,6 +190,10 @@ Specifies whether to enable the iburst option for every NTP peer. Valid options:
 
 Specifies one or more network interfaces for NTP to listen on. Valid options: array. Default value: [ ]
 
+####`interfaces_ignore`
+
+Specifies one or more ignore pattern for the NTP listener configuration (e.g. all, wildcard, ipv6, ...). Valid options: array. Default value: [ ]
+
 ####`keys_controlkey`
 
 Provides a control key to be used by NTP. Valid options: string. Default value: ' '

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -29,6 +29,7 @@ class ntp (
   $preferred_servers = $ntp::params::preferred_servers,
   $restrict          = $ntp::params::restrict,
   $interfaces        = $ntp::params::interfaces,
+  $interfaces_ignore = $ntp::params::interfaces_ignore,
   $servers           = $ntp::params::servers,
   $service_enable    = $ntp::params::service_enable,
   $service_ensure    = $ntp::params::service_ensure,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -21,6 +21,7 @@ class ntp::params {
   $udlc              = false
   $udlc_stratum      = '10'
   $interfaces        = []
+  $interfaces_ignore = []
   $disable_auth      = false
   $disable_kernel    = false
   $disable_monitor   = true

--- a/spec/classes/ntp_spec.rb
+++ b/spec/classes/ntp_spec.rb
@@ -126,6 +126,29 @@ describe 'ntp' do
           end
         end
 
+        describe 'specified ignore interfaces' do
+          context "when set" do
+            let(:params) {{
+              :interfaces => ['a.b.c.d'],
+              :interfaces_ignore => ['wildcard', 'ipv6']
+            }}
+
+            it { should contain_file('/etc/ntp.conf').with({
+              'content' => /interface ignore wildcard\ninterface ignore ipv6\ninterface listen a.b.c.d/})
+            }
+          end
+          context "when not set" do
+            let(:params) {{
+              :interfaces   => ['127.0.0.1'],
+              :servers      => ['a', 'b', 'c', 'd'],
+            }}
+
+            it { should contain_file('/etc/ntp.conf').with({
+              'content' => /interface ignore wildcard\ninterface listen 127.0.0.1/})
+            }
+          end
+        end
+
         describe 'with parameter disable_auth' do
           context 'when set to true' do
             let(:params) {{

--- a/templates/ntp.conf.erb
+++ b/templates/ntp.conf.erb
@@ -27,9 +27,15 @@ restrict <%= restrict %>
 <% end -%>
 
 <% if @interfaces != [] -%>
+<% if @interfaces_ignore != [] -%>
+<% @interfaces_ignore.flatten.each do |interface| -%>
+interface ignore <%= interface %>
+<% end -%>
+<% else -%>
 # Ignore wildcard interface and only listen on the following specified
 # interfaces
 interface ignore wildcard
+<% end -%>
 <% @interfaces.flatten.each do |interface| -%>
 interface listen <%= interface %>
 <% end -%>


### PR DESCRIPTION
The ntp configuration supports some tokens for interfaces that shall be ignored.
Previously the module used the pattern 'wildcard' to indicate that ntp
shouldn't listen to any interface but those specified as listen interfaces.
In some circumstances this is not enough. This commit adds a new parameter
interfaces_ignore that allows to list all interfaces (or interface tokens
like all, ipv6, ipv6 etc.) that should be ignored (and overrides the wildcard token).