### PR TITLE
Add support for the authprov parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -45,6 +45,7 @@ class ntp (
   $udlc              = $ntp::params::udlc,
   $udlc_stratum      = $ntp::params::udlc_stratum,
   $ntpsigndsocket    = $ntp::params::ntpsigndsocket,
+  $authprov          = $ntp::params::authprov,
 ) inherits ntp::params {
 
   validate_bool($broadcastclient)
@@ -88,6 +89,7 @@ class ntp (
   if $tos_cohort { validate_re($tos_cohort, '^[0|1]$', "Must be 0 or 1, got: ${tos_cohort}") }
   validate_bool($udlc)
   validate_array($peers)
+  if $authprov { validate_string($authprov) }
 
   if $config_dir {
     validate_absolute_path($config_dir)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -33,6 +33,7 @@ class ntp::params {
   $tos_cohort        = '0'
   $disable_dhclient  = false
   $ntpsigndsocket    = undef
+  $authprov          = undef
 
   # Allow a list of fudge options
   $fudge             = []

--- a/spec/classes/ntp_spec.rb
+++ b/spec/classes/ntp_spec.rb
@@ -605,6 +605,33 @@ describe 'ntp' do
           end
         end
 
+        describe 'with parameter authprov' do
+          context 'when set to true' do
+            let(:params) {{
+                :servers => ['a', 'b', 'c', 'd'],
+                :authprov => '/opt/novell/xad/lib64/libw32time.so 131072:4294967295 global',
+            }}
+
+            it 'should contain authprov setting' do
+              should contain_file('/etc/ntp.conf').with({
+                'content' => %r(^authprov /opt/novell/xad/lib64/libw32time.so 131072:4294967295 global\n),
+              })
+            end
+          end
+
+          context 'when set to false' do
+            let(:params) {{
+                :servers => ['a', 'b', 'c', 'd'],
+            }}
+
+            it 'should not contain a authprov line' do
+              should_not contain_file('/etc/ntp.conf').with({
+                'content' => /authprov /,
+              })
+            end
+          end
+        end
+
         describe 'with parameter tos' do
           context 'when set to true' do
             let(:params) {{

--- a/templates/ntp.conf.erb
+++ b/templates/ntp.conf.erb
@@ -103,3 +103,6 @@ leapfile <%= @leapfile %>
 tos <% if @tos_minclock -%> minclock <%= @tos_minclock %><% end %><% if @tos_minsane -%> minsane <%= @tos_minsane %><% end %><% if @tos_floor -%> floor <%= @tos_floor %><% end %><% if @tos_ceiling -%> ceiling <%= @tos_ceiling %><% end %><% if @tos_cohort -%> cohort <%= @tos_cohort %><% end %>
 <% end %>
 
+<% unless @authprov.nil? -%>
+authprov <%= @authprov %>
+<% end -%>


### PR DESCRIPTION
This parameter is used in some versions of NTPd (such as Novell DSfW) to
enable compatibility with W32Time.