### PR TITLE
Add a service_provider parameter in order to allow to specify

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -302,6 +302,10 @@ Tells Puppet whether to manage the NTP service. Valid options: 'true' or 'false'
 
 Tells Puppet what NTP service to manage. Valid options: string. Default value: varies by operating system
 
+####`service_provider`
+
+Tells Puppet what NTP service provider to use. Valid options: string. Default value: undef
+
 ####`stepout`
 
 Tells puppet to change stepout. Applies only if `tinker` value is 'true'. Valid options: unsigned shortint digit. Default value: undef.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -34,6 +34,7 @@ class ntp (
   $service_ensure    = $ntp::params::service_ensure,
   $service_manage    = $ntp::params::service_manage,
   $service_name      = $ntp::params::service_name,
+  $service_provider  = undef,
   $stepout           = $ntp::params::stepout,
   $tinker            = $ntp::params::tinker,
   $tos               = $ntp::params::tos,

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -10,6 +10,7 @@ class ntp::service inherits ntp {
       ensure     => $ntp::service_ensure,
       enable     => $ntp::service_enable,
       name       => $ntp::service_name,
+      provider   => $ntp::service_provider,
       hasstatus  => true,
       hasrestart => true,
     }


### PR DESCRIPTION
a service provider to manage the service.

This helps me with Puppet 3.7.3 on SLES 12, where the ntp service is managed via systemd and the but puppet tries to manage it via init service provider.

Let me know if there is something to change/enhance/etc.