### PR TITLE
Use config_dir for keys_file

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -208,7 +208,7 @@ Tells Puppet whether to enable key-based authentication. Valid options: 'true' o
 
 ####`keys_file`
 
-Specifies the complete path and location of the MD5 key file containing the keys and key identifiers used by ntpd, ntpq and ntpdc when operating with symmetric key cryptography. Valid options: string containing an absolute path. Default value: '/etc/ntp/keys' (except on AIX, SLES, and Solaris)
+Specifies the complete path and location of the MD5 key file containing the keys and key identifiers used by ntpd, ntpq and ntpdc when operating with symmetric key cryptography. Valid options: string containing an absolute path. Default value: '/etc/ntp.keys' (except on RedHat & Amazon where it is '/etc/ntp/keys')
 
 ####`keys_requestkey`
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -41,7 +41,7 @@ class ntp::params {
   $fudge             = []
 
   $default_config       = '/etc/ntp.conf'
-  $default_keys_file    = '/etc/ntp/keys'
+  $default_keys_file    = '/etc/ntp.keys'
   $default_driftfile    = '/var/lib/ntp/drift'
   $default_package_name = ['ntp']
   $default_service_name = 'ntpd'
@@ -63,7 +63,7 @@ class ntp::params {
   case $::osfamily {
     'AIX': {
       $config          = $default_config
-      $keys_file       = '/etc/ntp.keys'
+      $keys_file       = $default_keys_file
       $driftfile       = '/etc/ntp.drift'
       $package_name    = [ 'bos.net.tcp.client' ]
       $restrict        = [
@@ -105,7 +105,7 @@ class ntp::params {
     }
     'RedHat': {
       $config          = $default_config
-      $keys_file       = $default_keys_file
+      $keys_file       = '/etc/ntp/keys'
       $driftfile       = $default_driftfile
       $package_name    = $default_package_name
       $service_name    = $default_service_name
@@ -149,7 +149,7 @@ class ntp::params {
           case $::operatingsystemmajrelease {
             '10': {
               $service_name  = 'ntp'
-              $keys_file     = '/etc/ntp.keys'
+              $keys_file     = $default_keys_file
               $package_name  = [ 'xntp' ]
               $service_provider = undef
             }
@@ -161,7 +161,7 @@ class ntp::params {
             }
             '12': {
               $service_name  = 'ntpd'
-              $keys_file     = '/etc/ntp.keys'
+              $keys_file     = $default_keys_file
               $package_name  = $default_package_name
               #Puppet 3 does not recognise systemd as service provider on SLES 12.
               $service_provider = 'systemd'
@@ -176,7 +176,7 @@ class ntp::params {
           case $::operatingsystemrelease {
             '13.2': {
               $service_name  = 'ntpd'
-              $keys_file     = '/etc/ntp.keys'
+              $keys_file     = $default_keys_file
               $package_name  = $default_package_name
             }
             default: {
@@ -338,7 +338,7 @@ class ntp::params {
         }
         'Amazon': {
           $config          = $default_config
-          $keys_file       = $default_keys_file
+          $keys_file       = '/etc/ntp/keys'
           $driftfile       = $default_driftfile
           $package_name    = $default_package_name
           $service_name    = $default_service_name

--- a/spec/acceptance/ntp_parameters_spec.rb
+++ b/spec/acceptance/ntp_parameters_spec.rb
@@ -100,7 +100,6 @@ describe "ntp class:", :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamily'
       pp = <<-EOS
       class { 'ntp':
         keys_enable     => true,
-        keys_file       => '/etc/ntp/keys',
         keys_controlkey => '15',
         keys_requestkey => '1',
         keys_trusted    => [ '1', '2' ],

--- a/spec/classes/ntp_spec.rb
+++ b/spec/classes/ntp_spec.rb
@@ -44,7 +44,6 @@ describe 'ntp' do
           context "when enabled" do
             let(:params) {{
               :keys_enable     => true,
-              :keys_file       => '/etc/ntp/ntp.keys',
               :keys_trusted    => ['1', '2', '3'],
               :keys_controlkey => '2',
               :keys_requestkey => '3',
@@ -65,7 +64,6 @@ describe 'ntp' do
         context "when disabled" do
           let(:params) {{
             :keys_enable     => false,
-            :keys_file       => '/etc/ntp/ntp.keys',
             :keys_trusted    => ['1', '2', '3'],
             :keys_controlkey => '2',
             :keys_requestkey => '3',


### PR DESCRIPTION
The keys_file defaults to /etc/ntp/keys on many platforms, but the
packages do not create that directory. There is a parameter, config_dir
that can be used to manage this directory, though in our acceptance
tests there was a line that did an mkdir of this directory which was
removed in PR #314 and covered up the fact that the module would not
work by default on many platforms. This should get the tests working
again, and update the debian/ubuntu defaults to their documented
defaults.

Both Debian and Ubuntu actually specify /etc/ntp.keys as the default.
And freebsd, sles, opensuse, and archlinux.

RedHat is the only OS with /etc/ntp/keys as the true default, against
the ntpd standard.