### PR TITLE
Demonstrate adding beaker acceptance tests to a module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@
 sudo: false
 language: ruby
 cache: bundler
-bundler_args: --without system_tests
 script: "bundle exec rake validate lint spec"
 matrix:
   fast_finish: true
@@ -16,5 +15,17 @@ matrix:
     env: PUPPET_GEM_VERSION="~> 3.0"
   - rvm: 1.9.3
     env: PUPPET_GEM_VERSION="~> 3.0"
+  - rvm: 2.1.6
+    sudo: required
+    dist: trusty
+    services: docker
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_set="docker/ubuntu-14.04"
+    script: bundle exec rake beaker
+  - rvm: 2.1.6
+    sudo: required
+    dist: trusty
+    services: docker
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_set="docker/centos-7"
+    script: bundle exec rake beaker
 notifications:
   email: false

--- a/spec/acceptance/nodesets/docker/centos-7.yml
+++ b/spec/acceptance/nodesets/docker/centos-7.yml
@@ -1,0 +1,12 @@
+HOSTS:
+  centos-7-x64:
+    platform: el-7-x86_64
+    hypervisor : docker
+    image: centos:7
+    docker_preserve_image: true
+    docker_cmd: '["/usr/sbin/init"]'
+    docker_image_commands:
+      - 'yum install -y crontabs tar wget openssl'
+CONFIG:
+  log_level: verbose
+  trace_limit: 200

--- a/spec/acceptance/nodesets/docker/ubuntu-14.04.yml
+++ b/spec/acceptance/nodesets/docker/ubuntu-14.04.yml
@@ -1,0 +1,15 @@
+HOSTS:
+  ubuntu-1404-x64:
+    platform: ubuntu-14.04-amd64
+    hypervisor : docker
+    image: ubuntu:14.04
+    docker_preserve_image: true
+    docker_cmd: '["/sbin/init"]'
+    docker_image_commands:
+      - 'rm /usr/sbin/policy-rc.d'
+      - 'rm /sbin/initctl; dpkg-divert --rename --remove /sbin/initctl'
+      - 'apt-get install -y net-tools wget'
+      - 'locale-gen en_US.UTF-8'
+CONFIG:
+  log_level: debug
+  trace_limit: 200


### PR DESCRIPTION
As per internal conversations, this is a simple demonstration of running
the current acceptance tests on Centos and Ubuntu. This allows for
pre-merge testing and aims to help catch some obvious cross-OS issues
early.