### PR TITLE
Control the /etc/ntp/step-tickers file

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -39,6 +39,14 @@ class ntp::config inherits ntp {
     content => template($ntp::config_template),
   }
 
+  file { $::ntp::step_tickers:
+    ensure  => file,
+    owner   => 0,
+    group   => 0,
+    mode    => $::ntp::config_file_mode,
+    content => template($ntp::step_tickers_tpl),
+  }
+
   if $ntp::logfile {
     file { $ntp::logfile:
       ensure => file,

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -39,12 +39,14 @@ class ntp::config inherits ntp {
     content => template($ntp::config_template),
   }
 
-  file { $::ntp::step_tickers:
-    ensure  => file,
-    owner   => 0,
-    group   => 0,
-    mode    => $::ntp::config_file_mode,
-    content => template($ntp::step_tickers_tpl),
+  if $::ntp::step_tickers {
+    file { $::ntp::step_tickers:
+      ensure  => file,
+      owner   => 0,
+      group   => 0,
+      mode    => $::ntp::config_file_mode,
+      content => template($ntp::step_tickers_tpl),
+    }
   }
 
   if $ntp::logfile {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -38,6 +38,8 @@ class ntp (
   $service_name      = $ntp::params::service_name,
   $service_provider  = $ntp::params::service_provider,
   $stepout           = $ntp::params::stepout,
+  $step_tickers      = $ntp::params::step_tickers,
+  $step_tickers_tpl  = $ntp::params::step_tickers_tpl,
   $tinker            = $ntp::params::tinker,
   $tos               = $ntp::params::tos,
   $tos_minclock      = $ntp::params::tos_minclock,
@@ -84,6 +86,8 @@ class ntp (
   validate_bool($service_manage)
   validate_string($service_name)
   if $stepout { validate_numeric($stepout, 65535, 0) }
+  validate_string($step_tickers)
+  validate_string($step_tickers_tpl)
   validate_bool($tinker)
   validate_bool($tos)
   if $tos_minclock { validate_numeric($tos_minclock) }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -86,8 +86,10 @@ class ntp (
   validate_bool($service_manage)
   validate_string($service_name)
   if $stepout { validate_numeric($stepout, 65535, 0) }
-  validate_string($step_tickers)
-  validate_string($step_tickers_tpl)
+  if $step_tickers {
+    validate_string($step_tickers)
+    validate_string($step_tickers_tpl)
+  }
   validate_bool($tinker)
   validate_bool($tos)
   if $tos_minclock { validate_numeric($tos_minclock) }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,8 +19,6 @@ class ntp::params {
   $service_ensure    = 'running'
   $service_manage    = true
   $stepout           = undef
-  $step_tickers      = '/etc/ntp/step-tickers'
-  $step_tickers_tpl  = 'ntp/step-tickers.erb'
   $udlc              = false
   $udlc_stratum      = '10'
   $interfaces        = []
@@ -82,6 +80,8 @@ class ntp::params {
       ]
       $maxpoll         = undef
       $service_provider= undef
+      $step_tickers    = undef
+      $step_tickers_tpl= undef
     }
     'Debian': {
       $config          = $default_config
@@ -104,10 +104,14 @@ class ntp::params {
       ]
       $maxpoll         = undef
       $service_provider= undef
+      $step_tickers    = undef
+      $step_tickers_tpl= undef
     }
     'RedHat': {
       $config          = $default_config
       $keys_file       = '/etc/ntp/keys'
+      $step_tickers    = '/etc/ntp/step-tickers'
+      $step_tickers_tpl= 'ntp/step-tickers.erb'
       $driftfile       = $default_driftfile
       $package_name    = $default_package_name
       $service_name    = $default_service_name
@@ -211,6 +215,8 @@ class ntp::params {
         '3.opensuse.pool.ntp.org',
       ]
       $maxpoll         = undef
+      $step_tickers    = undef
+      $step_tickers_tpl= undef
     }
     'FreeBSD': {
       $config          = $default_config
@@ -233,6 +239,8 @@ class ntp::params {
       ]
       $maxpoll         = 9
       $service_provider= undef
+      $step_tickers    = undef
+      $step_tickers_tpl= undef
     }
     'Archlinux': {
       $config          = $default_config
@@ -255,6 +263,8 @@ class ntp::params {
       ]
       $maxpoll         = undef
       $service_provider= undef
+      $step_tickers    = undef
+      $step_tickers_tpl= undef
     }
     'Solaris': {
       $config        = '/etc/inet/ntp.conf'
@@ -286,8 +296,10 @@ class ntp::params {
         '2.pool.ntp.org',
         '3.pool.ntp.org',
       ]
-      $maxpoll       = undef
+      $maxpoll         = undef
       $service_provider= undef
+      $step_tickers    = undef
+      $step_tickers_tpl= undef
     }
   # Gentoo was added as its own $::osfamily in Facter 1.7.0
     'Gentoo': {
@@ -311,6 +323,8 @@ class ntp::params {
       ]
       $maxpoll         = undef
       $service_provider= undef
+      $step_tickers    = undef
+      $step_tickers_tpl= undef
     }
     'Linux': {
     # Account for distributions that don't have $::osfamily specific settings.
@@ -337,6 +351,8 @@ class ntp::params {
           ]
           $maxpoll         = undef
           $service_provider= undef
+          $step_tickers    = undef
+          $step_tickers_tpl= undef
         }
         'Amazon': {
           $config          = $default_config
@@ -359,6 +375,8 @@ class ntp::params {
           $maxpoll         = undef
           $service_provider= undef
           $disable_monitor = false
+          $step_tickers    = undef
+          $step_tickers_tpl= undef
         }
         default: {
           fail("The ${module_name} module is not supported on an ${::operatingsystem} distribution.")

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,6 +19,8 @@ class ntp::params {
   $service_ensure    = 'running'
   $service_manage    = true
   $stepout           = undef
+  $step_tickers      = '/etc/ntp/step-tickers'
+  $step_tickers_tpl  = 'ntp/step-tickers.erb'
   $udlc              = false
   $udlc_stratum      = '10'
   $interfaces        = []

--- a/spec/classes/ntp_spec.rb
+++ b/spec/classes/ntp_spec.rb
@@ -28,6 +28,9 @@ describe 'ntp' do
         it { should contain_file('/etc/ntp.conf').with_owner('0') }
         it { should contain_file('/etc/ntp.conf').with_group('0') }
         it { should contain_file('/etc/ntp.conf').with_mode('0644') }
+        it { should contain_file('/etc/ntp/step-tickers').with_owner('0') }
+        it { should contain_file('/etc/ntp/step-tickers').with_group('0') }
+        it { should contain_file('/etc/ntp/step-tickers').with_mode('0644') }
 
         if system == 'Suse12'
           it { should contain_file('/var/run/ntp/servers-netconfig').with_ensure_absent }
@@ -91,6 +94,9 @@ describe 'ntp' do
             it { should contain_file('/etc/ntp.conf').with({
               'content' => /server a prefer( maxpoll 9)?\nserver b prefer( maxpoll 9)?\nserver c( maxpoll 9)?\nserver d( maxpoll 9)?/})
             }
+            it { should contain_file('/etc/ntp/step-tickers').with({
+              'content' => /a\nb\nc\nd/})
+            }
           end
           context "when not set" do
             let(:params) {{
@@ -100,6 +106,9 @@ describe 'ntp' do
 
             it { should_not contain_file('/etc/ntp.conf').with({
               'content' => /server a prefer/})
+            }
+            it { should contain_file('/etc/ntp/step-tickers').with({
+              'content' => /a\nb\nc\nd/})
             }
           end
         end
@@ -720,6 +729,9 @@ describe 'ntp' do
           should contain_file('/etc/ntp.conf').with({
             'content' => /server \d.gentoo.pool.ntp.org/,
           })
+          should contain_file('/etc/ntp/step-tickers').with({
+            'content' => /\d.gentoo.pool.ntp.org/,
+          })
         end
       end
 
@@ -732,6 +744,9 @@ describe 'ntp' do
         it 'uses the NTP pool servers by default' do
           should contain_file('/etc/ntp.conf').with({
             'content' => /server \d.gentoo.pool.ntp.org/,
+          })
+          should contain_file('/etc/ntp/step-tickers').with({
+            'content' => /\d.gentoo.pool.ntp.org/,
           })
         end
       end
@@ -746,6 +761,9 @@ describe 'ntp' do
           should contain_file('/etc/ntp.conf').with({
             'content' => /server \d.debian.pool.ntp.org iburst\n/,
           })
+          should contain_file('/etc/ntp/step-tickers').with({
+            'content' => /\d.debian.pool.ntp.org/,
+          })
         end
       end
 
@@ -759,6 +777,9 @@ describe 'ntp' do
           should contain_file('/etc/ntp.conf').with({
             'content' => /server \d.centos.pool.ntp.org/,
           })
+          should contain_file('/etc/ntp/step-tickers').with({
+            'content' => /\d.centos.pool.ntp.org/,
+          })
         end
       end
 
@@ -771,6 +792,9 @@ describe 'ntp' do
           should contain_file('/etc/ntp.conf').with({
             'content' => /server \d.opensuse.pool.ntp.org/,
             })
+          should contain_file('/etc/ntp/step-tickers').with({
+            'content' => /\d.opensuse.pool.ntp.org/,
+          })
         end
       end
 
@@ -784,6 +808,9 @@ describe 'ntp' do
           should contain_file('/etc/ntp.conf').with({
             'content' => /server \d.freebsd.pool.ntp.org iburst maxpoll 9/,
           })
+          should contain_file('/etc/ntp/step-tickers').with({
+            'content' => /\d.freebsd.pool.ntp.org/,
+          })
         end
       end
 
@@ -796,6 +823,9 @@ describe 'ntp' do
         it 'uses the ArchLinux NTP servers by default' do
           should contain_file('/etc/ntp.conf').with({
             'content' => /server \d.arch.pool.ntp.org/,
+          })
+          should contain_file('/etc/ntp/step-tickers').with({
+            'content' => /\d.arch.pool.ntp.org/,
           })
         end
       end

--- a/spec/classes/ntp_spec.rb
+++ b/spec/classes/ntp_spec.rb
@@ -28,9 +28,12 @@ describe 'ntp' do
         it { should contain_file('/etc/ntp.conf').with_owner('0') }
         it { should contain_file('/etc/ntp.conf').with_group('0') }
         it { should contain_file('/etc/ntp.conf').with_mode('0644') }
-        it { should contain_file('/etc/ntp/step-tickers').with_owner('0') }
-        it { should contain_file('/etc/ntp/step-tickers').with_group('0') }
-        it { should contain_file('/etc/ntp/step-tickers').with_mode('0644') }
+
+        if system == 'RedHat' or system == 'Fedora'
+          it { should contain_file('/etc/ntp/step-tickers').with_owner('0') }
+          it { should contain_file('/etc/ntp/step-tickers').with_group('0') }
+          it { should contain_file('/etc/ntp/step-tickers').with_mode('0644') }
+        end
 
         if system == 'Suse12'
           it { should contain_file('/var/run/ntp/servers-netconfig').with_ensure_absent }
@@ -94,9 +97,6 @@ describe 'ntp' do
             it { should contain_file('/etc/ntp.conf').with({
               'content' => /server a prefer( maxpoll 9)?\nserver b prefer( maxpoll 9)?\nserver c( maxpoll 9)?\nserver d( maxpoll 9)?/})
             }
-            it { should contain_file('/etc/ntp/step-tickers').with({
-              'content' => /a\nb\nc\nd/})
-            }
           end
           context "when not set" do
             let(:params) {{
@@ -106,9 +106,6 @@ describe 'ntp' do
 
             it { should_not contain_file('/etc/ntp.conf').with({
               'content' => /server a prefer/})
-            }
-            it { should contain_file('/etc/ntp/step-tickers').with({
-              'content' => /a\nb\nc\nd/})
             }
           end
         end
@@ -729,9 +726,6 @@ describe 'ntp' do
           should contain_file('/etc/ntp.conf').with({
             'content' => /server \d.gentoo.pool.ntp.org/,
           })
-          should contain_file('/etc/ntp/step-tickers').with({
-            'content' => /\d.gentoo.pool.ntp.org/,
-          })
         end
       end
 
@@ -745,9 +739,6 @@ describe 'ntp' do
           should contain_file('/etc/ntp.conf').with({
             'content' => /server \d.gentoo.pool.ntp.org/,
           })
-          should contain_file('/etc/ntp/step-tickers').with({
-            'content' => /\d.gentoo.pool.ntp.org/,
-          })
         end
       end
 
@@ -760,9 +751,6 @@ describe 'ntp' do
         it 'uses the debian ntp servers by default' do
           should contain_file('/etc/ntp.conf').with({
             'content' => /server \d.debian.pool.ntp.org iburst\n/,
-          })
-          should contain_file('/etc/ntp/step-tickers').with({
-            'content' => /\d.debian.pool.ntp.org/,
           })
         end
       end
@@ -792,9 +780,6 @@ describe 'ntp' do
           should contain_file('/etc/ntp.conf').with({
             'content' => /server \d.opensuse.pool.ntp.org/,
             })
-          should contain_file('/etc/ntp/step-tickers').with({
-            'content' => /\d.opensuse.pool.ntp.org/,
-          })
         end
       end
 
@@ -808,9 +793,6 @@ describe 'ntp' do
           should contain_file('/etc/ntp.conf').with({
             'content' => /server \d.freebsd.pool.ntp.org iburst maxpoll 9/,
           })
-          should contain_file('/etc/ntp/step-tickers').with({
-            'content' => /\d.freebsd.pool.ntp.org/,
-          })
         end
       end
 
@@ -823,9 +805,6 @@ describe 'ntp' do
         it 'uses the ArchLinux NTP servers by default' do
           should contain_file('/etc/ntp.conf').with({
             'content' => /server \d.arch.pool.ntp.org/,
-          })
-          should contain_file('/etc/ntp/step-tickers').with({
-            'content' => /\d.arch.pool.ntp.org/,
           })
         end
       end

--- a/templates/step-tickers.erb
+++ b/templates/step-tickers.erb
@@ -1,0 +1,5 @@
+# List of NTP servers used by the ntpdate service.
+
+<% [@servers].flatten.each do |server| -%>
+<%= server %>
+<% end -%>


### PR DESCRIPTION
The /etc/ntp/step-tickers file is used by `ntpdate` on system boot to adjust system time before ntp initializes.  The default contents, at least on RHEL7, point to public pool servers.  If an organization has internal ntp servers, using internet time servers is undesirable (and may be firewalled off, anyway).

This adds support for managing the step-tickers file with the value of the `servers` array used in the `/etc/ntp.conf`.

Spec tests have been updated.

I admit that this may be a slightly heavy-handed approach, as I don't have anything other than RHEL7 handy with which to test.  I'm pretty sure this is broken for Solaris, and it may be broken for BSDs as well.  If someone would advise me on the correct file location for these distributions, I'll happily update this.