### PR TITLE
(MODULES-3660) Include ntp-perl and sntp for RedHat

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -111,7 +111,7 @@ class ntp::params {
       $keys_file          = '/etc/ntp/keys'
       $step_tickers_file  = '/etc/ntp/step-tickers'
       $driftfile          = $default_driftfile
-      $package_name       = $default_package_name
+      $package_name       = [ 'ntp', 'ntp-perl', 'sntp' ]
       $service_name       = $default_service_name
       $maxpoll            = undef
       $service_provider   = undef


### PR DESCRIPTION
Other platforms, notably Debian (and derivatives) include the tools in
these packages in their base "ntp" package.  Install the extra
packages to bring greater consistency to platforms when using the
module.