### PR TITLE
[MAINT] Update README to amend incorrect package_name description

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -253,7 +253,7 @@ Tells Puppet whether to manage the NTP package. Valid options: true or false. De
 
 ####`package_name`
 
-Tells Puppet what NTP package to manage. Valid options: string. Default value: 'ntp' (except on AIX and Solaris)
+Tells Puppet what NTP package to manage. Valid options: Array[string]. Default value: ['ntp'] (except on AIX and Solaris)
 
 ####`panic`
 


### PR DESCRIPTION
The NTP modules 'package_name' option only accepts an array of strings. The documentation on this is incorrect and states that the option accepts only a string. I have fixed this.