### PR TITLE
Added support for OpenSUSE Leap 42

### DIFF
--- a/data/OpenSuSE-42.yaml
+++ b/data/OpenSuSE-42.yaml
@@ -1,0 +1,2 @@
+ntp::service_name: ntpd
+ntp::service_provider: systemd

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,9 +1,15 @@
-# @api private 
+# @api private
 # This class handles the configuration file. Avoid modifying private classes.
 class ntp::config inherits ntp {
 
   #The servers-netconfig file overrides NTP config on SLES 12, interfering with our configuration.
   if $facts['operatingsystem'] == 'SLES' and $facts['operatingsystemmajrelease'] == '12' {
+    file { '/var/run/ntp/servers-netconfig':
+      ensure => 'absent'
+    }
+  }
+
+  if $facts['operatingsystem'] == 'OpenSuSE' and $facts['operatingsystemmajrelease'] == '42' {
     file { '/var/run/ntp/servers-netconfig':
       ensure => 'absent'
     }


### PR DESCRIPTION
Hello,

I would like to add support for OpenSuse Leap. The edits I made target major release 42 in order to future proof the next release of Leap 42.2.

Also, the file `/var/run/ntp/servers-netconfig` is present in OpenSuse Leap, so its absence is ensured using a regex and added the appropriate rspec test.

Please let me know if you would like to see any other changes or additions.
