### PR TITLE
Remove path to template file from keys.erb

### DIFF
--- a/templates/keys.erb
+++ b/templates/keys.erb
@@ -1,6 +1,4 @@
 # THIS FILE IS MANAGED BY PUPPET
-# <%= file %>
-#
 
 <% if @keys != [] -%>
 <% @keys.flatten.each do |keys| -%>


### PR DESCRIPTION
Letting the template file path get set is disruptive to environment
based test workflows, causing unnecessary events each time one
switches environment, e.g.:

    Notice: /Stage[main]/Ntp::Config/File[/etc/ntp/keys]/content:
    --- /etc/ntp/keys       2016-09-23 14:36:07.000000000 +0200
    +++ /tmp/puppet-file20160923-14521-1j0zq8t      2016-09-23
20:16:06.000000000 +0200
    @@ -1,4 +1,4 @@
     # THIS FILE IS MANAGED BY PUPPET
    -#
/etc/puppet/environments/production/puppet/forge/ntp/templates/keys.erb
    +#
/etc/puppet/environments/foo/puppet/forge/ntp/templates/keys.erb
     #