### PR TITLE
MODULES-3898 - ntp step-tickers should honor preferred servers

### DIFF
--- a/templates/step-tickers.erb
+++ b/templates/step-tickers.erb
@@ -1,5 +1,14 @@
 # List of NTP servers used by the ntpdate service.
 
+<% if @preferred_servers.empty? -%>
 <% [@servers].flatten.each do |server| -%>
 <%= server %>
 <% end -%>
+<% else -%>
+<% [@servers].flatten.each do |server| -%>
+<% if @preferred_servers.include?(server) -%>
+<%= server %>
+<% end -%>
+<% end -%>
+<% end -%>
+


### PR DESCRIPTION
This patch keeps the existing behavior for environments without
preferred servers.  For environments with preferred servers
step-tickers now only contains the preferred ntp sources.