### PR TITLE
Revert changes to spec_helper_acceptance

### DIFF
--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -13,9 +13,23 @@ unless ENV['RS_PROVISION'] == 'no' or ENV['BEAKER_provision'] == 'no'
     environmentpath = host.puppet['environmentpath']
     environmentpath = environmentpath.split(':').first if environmentpath
 
-    destdir = "#{environmentpath}/production/modules"
-    on host, "git clone -b master https://github.com/puppetlabs/puppetlabs-stdlib #{destdir}/stdlib"
-    on host, "git clone -b master https://github.com/voxpupuli/puppet-tea #{destdir}/tea"
+    # Solaris 11 doesn't ship the SSL CA root for the forgeapi server
+    # therefore we need to use a different way to deploy the module to
+    # the host
+    if host['platform'] =~ /solaris-11/i
+      apply_manifest_on(host, 'package { "git": }')
+      # PE 3.x and 2015.2 require different locations to install modules
+      modulepath = host.puppet['modulepath']
+      modulepath = modulepath.split(':').first if modulepath
+
+      environmentpath = host.puppet['environmentpath']
+      environmentpath = environmentpath.split(':').first if environmentpath
+
+      destdir = modulepath || "#{environmentpath}/production/modules"
+      on host, "git clone -b 4.13.0 https://github.com/puppetlabs/puppetlabs-stdlib #{destdir}/stdlib"
+    else
+      on host, puppet('module install puppetlabs-stdlib')
+    end
 
     # Need to disable update of ntp servers from DHCP, as subsequent restart of ntp causes test failures
     if fact_on(host, 'osfamily') == 'Debian'


### PR DESCRIPTION
Now that stdlib 4.13.0 has been released, we should be using the released
version. Also puppet-tea is not used. And the git code failed on several
platforms (rhel5, centos 5, oracle 5, sles 10, 12) with git not being
available.