### PR TITLE
[WIP] POC test tiering effort

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,9 @@ end
 # Used for gem conditionals
 supports_windows = false
 
+gem 'pry'
+gem 'pry-byebug'
+
 group :development do
   gem 'puppet-lint',                        :require => false
   gem 'metadata-json-lint',                 :require => false
@@ -56,9 +59,10 @@ group :system_tests do
   gem 'beaker-pe',                                                               :require => false if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.3.0')
   gem 'beaker-rspec', *location_for(ENV['BEAKER_RSPEC_VERSION'] || '>= 3.4')     if ! supports_windows
   gem 'beaker-rspec', *location_for(ENV['BEAKER_RSPEC_VERSION'] || '~> 5.1')     if supports_windows
-  gem 'beaker-puppet_install_helper',                                            :require => false
-  gem 'master_manipulator',                                                      :require => false
+  gem 'beaker-puppet_install_helper',:path => '/Users/wilson/repos/beaker-puppet_install_helper'
+  gem 'master_manipulator', :path => '/Users/wilson/repos/master_manipulator'
   gem 'beaker-hostgenerator', *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'])
+  gem 'beaker-testmode_switcher', :path => '/Users/wilson/repos/beaker-testmode_switcher'
 end
 
 gem 'puppet', *location_for(ENV['PUPPET_GEM_VERSION'])

--- a/Rakefile
+++ b/Rakefile
@@ -36,3 +36,64 @@ task :gen_nodeset do
   end
   puts nodeset
 end
+
+require 'rspec/core/rake_task'
+desc 'test tiering'
+RSpec::Core::RakeTask.new(:test_tier) do |t|
+
+  # Test mode must always be set
+  test_mode = ENV['BEAKER_TESTMODE'].to_sym
+  raise 'BEAKER_TESTMODE env variable must be either agent or apply.' unless %w(agent apply).include?(test_mode.to_s)
+
+  # If no hosts file is set, use beaker-hostgenerator to build one based on env variables
+  # BEAKER_MASTER & BEAKER_AGENT env variables accept valid beaker-hostgenerator platforms
+  # test_mode = agent
+  #   PE_DIR        - required.
+  #   BEAKER_MASTER - required.
+  #   BEAKER_AGENT  - optional - if not set this will run master and agent on one VM.
+  # test_mode = apply
+  #   BEAKER_AGENT  - required.
+  if(!ENV['BEAKER_setfile'] and !ENV['BEAKER_set'])
+    raise 'Cannot use apply testmode without specifying an agent' if(test_mode == :apply and !ENV['BEAKER_AGENT'])
+    raise 'Cannot use agent testmode without specifying a master' if(test_mode == :agent and !ENV['BEAKER_MASTER'])
+    raise 'Cannot use agent testmode without specifying a pe dir' if(test_mode == :agent and !ENV['PE_DIR'])
+
+    hostgen_string = 'beaker-hostgenerator '
+    if(test_mode == :agent)
+      hostgen_string += ENV['BEAKER_MASTER']
+      if(ENV['BEAKER_AGENT'])
+        # 1 x Master - 1 x Agent setup
+        hostgen_string += 'mdcl-' + ENV['BEAKER_AGENT'] + 'default.af'
+      else
+        # All in one master/agent on one box
+        hostgen_string += 'default.mdclaf'
+      end
+      hostgen_string += ' --pe_dir ' + ENV['PE_DIR']
+    elsif(test_mode == :apply)
+      # Agent only install
+      hostgen_string += ENV['BEAKER_AGENT'] + 'default.a'
+    end
+    ENV['BEAKER_set'] = 'autogen_beaker_set'
+  end
+
+  # Generate the nodeset file
+  sh hostgen_string + ' > spec/acceptance/nodesets/autogen_beaker_set.yml'
+
+  # Setup rspec opts
+  t.rspec_opts = ['--color']
+
+  # TEST_TIERS env variable is a comma separated list of tiers to run. e.g. low-medium-high
+  if ENV['TEST_TIERS']
+    test_tiers = ENV['TEST_TIERS'].split(',')
+    raise 'TEST_TIERS env variable must have at least 1 tier specified. low, medium or high (comma separated).' if test_tiers.count == 0
+    test_tiers.each do |tier|
+      raise "#{tier} not a valid test tier." unless %w(low medium high).include?(tier)
+      t.rspec_opts.push("--tag tier_#{tier}")
+    end
+  else
+    puts 'TEST_TIERS env variable not defined. Defaulting to run all tests.'
+  end
+
+  # Implement an override for the pattern with BEAKER_PATTERN env variable.
+  t.pattern = ENV['BEAKER_PATTERN'] ? ENV['BEAKER_PATTERN'] : 'spec/acceptance'
+end

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -1,35 +1,35 @@
 require 'spec_helper_acceptance'
 
 describe 'ntp class:', :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamily')) do
-  it 'should run successfully' do
+  it 'should run successfully', :tier_high => true do
     pp = "class { 'ntp': }"
 
     # Apply twice to ensure no errors the second time.
-    apply_manifest(pp, :catch_failures => true) do |r|
+    execute_manifest(pp, :catch_failures => true) do |r|
       expect(r.stderr).not_to match(/error/i)
     end
-    apply_manifest(pp, :catch_failures => true) do |r|
+    execute_manifest(pp, :catch_failures => true) do |r|
       expect(r.stderr).not_to eq(/error/i)
 
       expect(r.exit_code).to be_zero
     end
   end
 
-  context 'service_ensure => stopped:' do
+  context 'service_ensure => stopped:', :tier_medium => true do
     it 'runs successfully' do
       pp = "class { 'ntp': service_ensure => stopped }"
 
-      apply_manifest(pp, :catch_failures => true) do |r|
+      execute_manifest(pp, :catch_failures => true) do |r|
         expect(r.stderr).not_to match(/error/i)
       end
     end
   end
 
-  context 'service_ensure => running:' do
+  context 'service_ensure => running:', :tier_low => true do
     it 'runs successfully' do
       pp = "class { 'ntp': service_ensure => running }"
 
-      apply_manifest(pp, :catch_failures => true) do |r|
+      execute_manifest(pp, :catch_failures => true) do |r|
         expect(r.stderr).not_to match(/error/i)
       end
     end

--- a/spec/acceptance/disable_monitoring_spec.rb
+++ b/spec/acceptance/disable_monitoring_spec.rb
@@ -11,8 +11,8 @@ describe "ntp class with disable_monitor:", :unless => UNSUPPORTED_PLATFORMS.inc
     pp = "class { 'ntp': disable_monitor => true }"
 
     it 'runs twice' do
-      apply_manifest(pp, :catch_failures => true)
-      apply_manifest(pp, :catch_changes => true)
+      execute_manifest(pp, :catch_failures => true)
+      execute_manifest(pp, :catch_changes => true)
     end
 
     describe file("#{config}") do
@@ -24,8 +24,8 @@ describe "ntp class with disable_monitor:", :unless => UNSUPPORTED_PLATFORMS.inc
     pp = "class { 'ntp': disable_monitor => false }"
 
     it 'runs twice' do
-      apply_manifest(pp, :catch_failures => true)
-      apply_manifest(pp, :catch_changes => true)
+      execute_manifest(pp, :catch_failures => true)
+      execute_manifest(pp, :catch_changes => true)
     end
 
     describe file("#{config}") do

--- a/spec/acceptance/ntp_config_spec.rb
+++ b/spec/acceptance/ntp_config_spec.rb
@@ -37,7 +37,7 @@ end
 
 describe 'ntp::config class', :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamily')) do
   it 'sets up ntp.conf' do
-    apply_manifest(%{
+    execute_manifest(%{
       class { 'ntp': }
     }, :catch_failures => true)
   end

--- a/spec/acceptance/ntp_install_spec.rb
+++ b/spec/acceptance/ntp_install_spec.rb
@@ -31,7 +31,7 @@ end
 
 describe 'ntp::install class', :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamily')) do
   it 'installs the package' do
-    apply_manifest(%{
+    execute_manifest(%{
       class { 'ntp': }
     }, :catch_failures => true)
   end

--- a/spec/acceptance/ntp_parameters_spec.rb
+++ b/spec/acceptance/ntp_parameters_spec.rb
@@ -47,14 +47,14 @@ describe "ntp class:", :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamily'
   # FM-5470, this was added to reset failed count and work around puppet 3.x
   if ( (fact('operatingsystem') == 'SLES' and fact('operatingsystemmajrelease') == '12') or (fact('operatingsystem') == 'Scientific' and fact('operatingsystemmajrelease') == '7') )
     after :each do
-      shell('systemctl reset-failed ntpd.service')
+      on(default, 'systemctl reset-failed ntpd.service')
     end
   end
 
   it 'applies successfully' do
     pp = "class { 'ntp': }"
 
-    apply_manifest(pp, :catch_failures => true) do |r|
+    execute_manifest(pp, :catch_failures => true) do |r|
       expect(r.stderr).not_to match(/error/i)
     end
   end
@@ -62,7 +62,7 @@ describe "ntp class:", :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamily'
   describe 'config' do
     it 'sets the ntp.conf location' do
       pp = "class { 'ntp': config => '/etc/antp.conf' }"
-      apply_manifest(pp, :catch_failures => true)
+      execute_manifest(pp, :catch_failures => true)
     end
 
     describe file('/etc/antp.conf') do
@@ -73,14 +73,14 @@ describe "ntp class:", :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamily'
   describe 'config_template' do
     before :all do
       modulepath = default['distmoduledir']
-      shell("mkdir -p #{modulepath}/test/templates")
+      on(default, "mkdir -p #{modulepath}/test/templates")
       # Add spurious template logic to verify the use of the correct template rendering engine
-      shell("echo '<% [1].each do |i| %>erbserver<%= i %><%end %>' >> #{modulepath}/test/templates/ntp.conf.erb")
+      on(default, "echo '<% [1].each do |i| %>erbserver<%= i %><%end %>' >> #{modulepath}/test/templates/ntp.conf.erb")
     end
 
     it 'sets the ntp.conf erb template location' do
       pp = "class { 'ntp': config_template => 'test/ntp.conf.erb' }"
-      apply_manifest(pp, :catch_failures => true)
+      execute_manifest(pp, :catch_failures => true)
     end
 
     describe file("#{config}") do
@@ -90,21 +90,22 @@ describe "ntp class:", :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamily'
 
     it 'sets the ntp.conf epp template location and the ntp.conf erb template location which should fail' do
       pp = "class { 'ntp': config_template => 'test/ntp.conf.erb', config_epp => 'test/ntp.conf.epp' }"
-      expect(apply_manifest(pp, :expect_failures => true).stderr).to match(/Cannot supply both config_epp and config_template/i)
+      expect(execute_manifest(pp, :expect_failures => true).stderr).to match(/Cannot supply both config_epp and config_template/i)
     end
   end
 
   describe 'config_epp' do
     before :all do
       modulepath = default['distmoduledir']
-      shell("mkdir -p #{modulepath}/test/templates")
+      binding.pry;
+      on(default, "mkdir -p #{modulepath}/test/templates")
       # Add spurious template logic to verify the use of the correct template rendering engine
-      shell("echo '<% [1].each |$i| { -%>eppserver<%= $i %><% } -%>' >> #{modulepath}/test/templates/ntp.conf.epp")
+      on(default, "echo '<% [1].each |$i| { -%>eppserver<%= $i %><% } -%>' >> #{modulepath}/test/templates/ntp.conf.epp")
     end
 
     it 'sets the ntp.conf epp template location' do
       pp = "class { 'ntp': config_epp => 'test/ntp.conf.epp' }"
-      apply_manifest(pp, :catch_failures => true)
+      execute_manifest(pp, :catch_failures => true)
     end
 
     describe file("#{config}") do
@@ -114,14 +115,14 @@ describe "ntp class:", :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamily'
 
     it 'sets the ntp.conf epp template location and the ntp.conf erb template location which should fail' do
       pp = "class { 'ntp': config_template => 'test/ntp.conf.erb', config_epp => 'test/ntp.conf.epp' }"
-      expect(apply_manifest(pp, :expect_failures => true).stderr).to match(/Cannot supply both config_epp and config_template/i)
+      expect(execute_manifest(pp, :expect_failures => true).stderr).to match(/Cannot supply both config_epp and config_template/i)
     end
   end
 
   describe 'driftfile' do
     it 'sets the driftfile location' do
       pp = "class { 'ntp': driftfile => '/tmp/driftfile' }"
-      apply_manifest(pp, :catch_failures => true)
+      execute_manifest(pp, :catch_failures => true)
     end
 
     describe file("#{config}") do
@@ -141,7 +142,7 @@ describe "ntp class:", :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamily'
         keys            => [ '1 M AAAABBBB' ],
       }
       EOS
-      apply_manifest(pp, :catch_failures => true)
+      execute_manifest(pp, :catch_failures => true)
     end
 
     describe file("#{config}") do
@@ -166,7 +167,7 @@ describe "ntp class:", :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamily'
         package_name   => #{Array(packagename).inspect},
       }
       EOS
-      apply_manifest(pp, :catch_failures => true)
+      execute_manifest(pp, :catch_failures => true)
     end
 
     Array(packagename).each do |package|
@@ -183,7 +184,7 @@ describe "ntp class:", :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamily'
         panic => 0,
       }
       EOS
-      apply_manifest(pp, :catch_failures => true)
+      execute_manifest(pp, :catch_failures => true)
     end
 
     describe file("#{config}") do
@@ -198,7 +199,7 @@ describe "ntp class:", :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamily'
         panic => 1,
       }
       EOS
-      apply_manifest(pp, :catch_failures => true)
+      execute_manifest(pp, :catch_failures => true)
     end
 
     describe file("#{config}") do
@@ -209,7 +210,7 @@ describe "ntp class:", :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamily'
   describe 'udlc' do
     it 'adds a udlc' do
       pp = "class { 'ntp': udlc => true }"
-      apply_manifest(pp, :catch_failures => true)
+      execute_manifest(pp, :catch_failures => true)
     end
 
     describe file("#{config}") do
@@ -221,7 +222,7 @@ describe "ntp class:", :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamily'
   describe 'udlc_stratum' do
     it 'sets the stratum value when using udlc' do
       pp = "class { 'ntp': udlc => true, udlc_stratum => 10 }"
-      apply_manifest(pp, :catch_failures => true)
+      execute_manifest(pp, :catch_failures => true)
     end
 
     describe file("#{config}") do

--- a/spec/acceptance/ntp_service_spec.rb
+++ b/spec/acceptance/ntp_service_spec.rb
@@ -37,7 +37,7 @@ end
 describe 'ntp::service class', :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamily')) do
   describe 'basic test' do
     it 'sets up the service' do
-      apply_manifest(%{
+      execute_manifest(%{
         class { 'ntp': }
       }, :catch_failures => true)
     end
@@ -55,7 +55,7 @@ describe 'ntp::service class', :unless => UNSUPPORTED_PLATFORMS.include?(fact('o
         service_name   => '#{servicename}'
       }
       EOS
-      apply_manifest(pp, :catch_failures => true)
+      execute_manifest(pp, :catch_failures => true)
     end
     it_should_behave_like 'running'
   end
@@ -71,7 +71,7 @@ describe 'service is unmanaged' do
         service_name   => '#{servicename}'
       }
     EOS
-    apply_manifest(pp, :catch_failures => true)
+    execute_manifest(pp, :catch_failures => true)
   end
 
   describe service(servicename) do

--- a/spec/acceptance/preferred_servers_spec.rb
+++ b/spec/acceptance/preferred_servers_spec.rb
@@ -15,7 +15,7 @@ describe 'preferred servers', :unless => UNSUPPORTED_PLATFORMS.include?(fact('os
   EOS
 
   it 'applies cleanly' do
-    apply_manifest(pp, :catch_failures => true) do |r|
+    execute_manifest(pp, :catch_failures => true) do |r|
       expect(r.stderr).not_to match(/error/i)
     end
   end

--- a/spec/acceptance/restrict_spec.rb
+++ b/spec/acceptance/restrict_spec.rb
@@ -11,7 +11,7 @@ describe "ntp class with restrict:", :unless => UNSUPPORTED_PLATFORMS.include?(f
     it 'runs twice' do
       pp = "class { 'ntp': restrict => ['test restrict']}"
       2.times do
-        apply_manifest(pp, :catch_failures => true) do |r|
+        execute_manifest(pp, :catch_failures => true) do |r|
           expect(r.stderr).not_to match(/error/i)
         end
       end

--- a/spec/acceptance/unsupported_spec.rb
+++ b/spec/acceptance/unsupported_spec.rb
@@ -5,6 +5,6 @@ describe 'unsupported distributions and OSes', :if => UNSUPPORTED_PLATFORMS.incl
     pp = <<-EOS
     class { 'ntp': }
     EOS
-    expect(apply_manifest(pp, :expect_failures => true).stderr).to match(/is not supported on an/i)
+    expect(execute_manifest(pp, :expect_failures => true).stderr).to match(/is not supported on an/i)
   end
 end


### PR DESCRIPTION
For this to work, you will need this PR to be merged: [PR](https://github.com/puppetlabs/beaker-testmode_switcher/pull/4). After this you will need to update the Gemfile to point to the correct testmode_switcher location. Currently pointing to my local version for dev purposes.

This PR does the following:
 - Implementing testmode switcher within the tests to support master/agent and agent only testing
 - Rake task to autogen a beaker host and run a specified set of tiers in the given testmode on a master/agent or agent only setup
 - spec_helper_acceptance updated to do the setup of the system correctly depending on the BEAKER_TESTMODE env var
 - Tag **SOME** tests with a tier (class_spec.rb) and implement TEST_TIERS env variable which accepts a comma separated list of tiers to run e.g. 'high,medium,low'. Tier naming TBD.

BEAKER_TESTMODE=agent currently only installs PE. Foss is not supported currently due to an issue with beaker. 

BEAKER_MASTER and BEAKER_AGENT accept a valid platform, available from beaker-hostgenerator --list command.

How to run:
**Separate Master/Agent**: 
BEAKER_TESTMODE=agent BEAKER_MASTER=[platform]  BEAKER_AGENT=[platform] TEST_TIERS=[comma,separated,tiers] PE_DIR=[pe dir] BEAKER_debug=yes bundle exec rake test_tier
**All-in-one Master/Agent** (Untested currently, although should work): 
BEAKER_TESTMODE=agent BEAKER_MASTER=[platform] TEST_TIERS=[comma,separated,tiers] PE_DIR=[pe dir] BEAKER_debug=yes bundle exec rake test_tier
**Single Agent Only**: 
BEAKER_TESTMODE=apply  BEAKER_AGENT=[platform] TEST_TIERS=[comma,separated,tiers] BEAKER_debug=yes bundle exec rake test_tier