### PR TITLE
Reverse Solaris-11 and Solaris transpose fix

### DIFF
--- a/data/Solaris-11.yaml
+++ b/data/Solaris-11.yaml
@@ -1,4 +1,11 @@
-ntp::package_name: [ 'SUNWntpr', 'SUNWntpu' ]
+ntp::config: '/etc/inet/ntp.conf'
+ntp::driftfile: '/var/ntp/ntp.drift'
+ntp::keys_file: '/etc/inet/ntp.keys'
+ntp::package_name: [ 'service/network/ntp' ]
 ntp::restrict:
-  - 'default nomodify notrap nopeer noquery'
+  - 'default kod nomodify notrap nopeer noquery'
+  - '-6 default kod nomodify notrap nopeer noquery'
   - '127.0.0.1'
+  - '-6 ::1'
+ntp::service_name: 'network/ntp'
+ntp::iburst_enable: false

--- a/data/Solaris.yaml
+++ b/data/Solaris.yaml
@@ -1,11 +1,9 @@
 ntp::config: '/etc/inet/ntp.conf'
 ntp::driftfile: '/var/ntp/ntp.drift'
 ntp::keys_file: '/etc/inet/ntp.keys'
-ntp::package_name: [ 'service/network/ntp' ]
+ntp::package_name: [ 'SUNWntpr', 'SUNWntpu' ]
 ntp::restrict:
-  - 'default kod nomodify notrap nopeer noquery'
-  - '-6 default kod nomodify notrap nopeer noquery'
+  - 'default nomodify notrap nopeer noquery'
   - '127.0.0.1'
-  - '-6 ::1'
 ntp::service_name: 'network/ntp'
 ntp::iburst_enable: false


### PR DESCRIPTION
The commit to params to data-in-modules got the Solaris
data backawards.

https://github.com/puppetlabs/puppetlabs-ntp/commit/5a6bfb71fe1f4796964400f2fc264c8094786d5c