### PR TITLE
POC - Tagging tests for node specific tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,9 +57,11 @@ group :system_tests do
   gem 'beaker-rspec', *location_for(ENV['BEAKER_RSPEC_VERSION'] || '>= 3.4')     if ! supports_windows
   gem 'beaker-rspec', *location_for(ENV['BEAKER_RSPEC_VERSION'] || '~> 5.1')     if supports_windows
   gem 'beaker-puppet_install_helper',                                            :require => false
-  gem 'master_manipulator',                                                      :require => false
+  gem 'master_manipulator'
   gem 'beaker-hostgenerator', *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'])
-  gem 'beaker-abs', *location_for(ENV['BEAKER_ABS_VERSION'] || '~> 0.1')        
+  gem 'beaker-abs', *location_for(ENV['BEAKER_ABS_VERSION'] || '~> 0.1')
+  gem 'nokogiri', '1.6.8.1'
+  gem 'beaker-testmode_switcher', :path => '/Users/paula/puppet_repos/testing/beaker-testmode_switcher'
 end
 
 gem 'puppet', *location_for(ENV['PUPPET_GEM_VERSION'])

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,8 @@
 require 'puppet_blacksmith/rake_tasks'
 require 'puppet-lint/tasks/puppet-lint'
 require 'puppetlabs_spec_helper/rake_tasks'
+require 'rspec/core/rake_task'
+
 
 PuppetLint.configuration.send('relative')
 PuppetLint.configuration.send('disable_documentation')
@@ -35,4 +37,30 @@ task :gen_nodeset do
     fh.print(cli.execute)
   end
   puts nodeset
+end
+
+
+desc 'Running acceptance test on single and multi node set ups, nodeset needs provided by the user'
+RSpec::Core::RakeTask.new(:tag) do |t|
+  # Test mode must always be set
+  test_mode = ENV['BEAKER_TESTMODE'].to_sym
+  raise 'BEAKER_TESTMODE env variable must be either agent or apply.' unless %w(agent apply).include?(test_mode.to_s)
+
+  # Setup rspec opts
+  t.rspec_opts = ['--color']
+
+  # NODE_SETUP env variable is a comma separated list of node setups to run. e.g. singlenode, multinode
+  if ENV['NODE_setup']
+    node_setup = ENV['NODE_setup'].split(',')
+    raise 'NODE_setup env variable must have at least 1 node setup specified. low, medium or high (comma separated).' if node_setup.count == 0
+    node_setup.each do |node|
+      raise "#{node} not a valid node setup." unless %w(singlenode multinode).include?(node)
+      t.rspec_opts.push("--tag #{node}")
+    end
+  else
+    puts 'NODE_setup env variable not defined. Defaulting to run all tests.'
+  end
+
+  # Implement an override for the pattern with BEAKER_PATTERN env variable.
+  t.pattern = ENV['BEAKER_PATTERN'] ? ENV['BEAKER_PATTERN'] : 'spec/acceptance'
 end

--- a/spec/acceptance/paula_spec.rb
+++ b/spec/acceptance/paula_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper_acceptance'
+require 'specinfra'
+
+a1 = find_host_with_role('a1')
+a2 = find_host_with_role('a2')
+
+  pp1 = <<-EOS
+      class { '::ntp': servers => ['a', 'b', 'c', 'd'],preferred_servers => ['c', 'd'],}
+  EOS
+
+  pp2 = <<-EOS
+      class { '::ntp':servers => ['1', '2', '3', '4'], preferred_servers => ['2', '4'],}
+  EOS
+
+  pp = <<-EOS
+      class { '::ntp':}
+  EOS
+
+  describe "Multinode tests", :multinode => true do
+    it 'System test - apply 2 different manifests, confirm same config' do
+      # Putting the servers into a known state
+      # execute_manifest_on(hosts, pp4, :catch_failures => true, :acceptable_exit_codes => [0, 2])
+      execute_manifest_on(a1, pp, :catch_failures => true, :acceptable_exit_codes => [0, 2])
+      execute_manifest_on(a2, pp, :catch_failures => true, :acceptable_exit_codes => [0, 2])
+
+      # Doing an agent run to configure preferred servers on specific server
+      execute_manifest_on(a1, pp1, :catch_failures => true, :acceptable_exit_codes => [0, 2])
+
+      # Doing an agent run to configure preferred servers on specific server
+      execute_manifest_on(a2, pp2, :catch_failures => true, :acceptable_exit_codes => [0, 2])
+
+      # Doing a final run to ensure the first server configures to the same as the second
+      on a1, 'puppet agent --test --environment production', :catch_failures => true, :acceptable_exit_codes => [0, 2]
+    end
+
+    # Checking file content is as expected on one server
+    it 'Checks file content is correct on a1' do
+      result1 = on(a1, 'cat /etc/ntp.conf' )
+      expect( result1.stdout ).to match 'server 1'
+      expect( result1.stdout ).to match 'server 3'
+      expect( result1.stdout ).to match /server 2 (iburst\s|)prefer/
+      expect( result1.stdout ).to match /server 4 (iburst\s|)prefer/
+    end
+
+    # Checking file content is as expected on one server
+    it 'Checks file content is correct on a2' do
+      result2 = on(a2, 'cat /etc/ntp.conf' )
+      expect( result2.stdout ).to match 'server 1'
+      expect( result2.stdout ).to match 'server 3'
+      expect( result2.stdout ).to match /server 2 (iburst\s|)prefer/
+      expect( result2.stdout ).to match /server 4 (iburst\s|)prefer/
+    end
+  end
+
+describe 'service parameters', :singlenode => true do
+  it 'starts the service' do
+    pp = <<-EOS
+      class { 'ntp': service_enable => true, service_ensure => running, service_manage => true,}
+    EOS
+    execute_manifest(pp, :catch_failures => true)
+  end
+  it_should_behave_like 'running'
+end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,5 +1,7 @@
 require 'beaker-rspec'
 require 'beaker/puppet_install_helper'
+require 'beaker/testmode_switcher'
+require 'beaker/testmode_switcher/dsl'
 
 UNSUPPORTED_PLATFORMS = ['windows', 'Darwin']
 


### PR DESCRIPTION
**Purpose:** 
The purpose of this task was to come up with a method to run tests as a multinode or single node setup using beaker-testmode_switcher Single node test you would want to ensure that NTP service can run. Using multiple nodes provides you with the opportunity to write more 'interesting' tests. Making use of execute_manifest_on allows me to control where I was tests to run.

_spec/acceptance/paula_spec.rb_ contains both singlenode and multinode tests, testing the following scenarios:
1. Singlenode: Ensuring that NTP service can run
2. Multinode: apply manifest to a1, apply different manifest to a2, do a puppet agent run on a1, a1 should now match a2 config

It is assumed the user provides the correct nodeset required for the tests to run with specific roles to allow targeting a specific node, this example uses a role ‘a1’ and ‘a2’ but this can be anything. 

**How to run the tests**
- Multinode: 
BEAKER_TESTMODE=agent BEAKER_set=autogen_beaker_set BEAKER_provision=no BEAKER_destroy=no BEAKER_debug=true NODE_setup=multinode bundle exec rake tag

- Singlenode:
BEAKER_TESTMODE=agent BEAKER_set=autogen_beaker_set BEAKER_provision=no BEAKER_destroy=no BEAKER_debug=true NODE_setup=singlenode bundle exec rake tag

- Both:
BEAKER_TESTMODE=agent BEAKER_set=autogen_beaker_set BEAKER_provision=no BEAKER_destroy=no BEAKER_debug=true NODE_setup=singlenode,multinode bundle exec rake tag

**Note if you don't get NODE_setup env it will default and run all tests, be aware some tests may fail depending on how they have been written.**

Rototiller has not been implemented to enforce variables as this is only a POC of it working.
The following naming conventions have been used as a POC but can be changed to more meaningful names at any point: singlenode, multinode, NODE_setup, node