### PR TITLE
Fix for syntax; add maxclock params; specify tested version of FreeBSD platform

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -51,6 +51,7 @@ ntp::tos_ceiling: 15
 ntp::tos_cohort: 0
 ntp::tos_floor: 1
 ntp::tos_minclock: 3
+ntp::tos_maxclock: 6
 ntp::tos_minsane: 1
 ntp::tos: false
 ntp::udlc_stratum: 10

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -43,6 +43,7 @@ class ntp (
   Optional[String] $step_tickers_template,
   Optional[Boolean] $tinker,
   Boolean $tos,
+  Optional[Integer[1]] $tos_maxclock,
   Optional[Integer[1]] $tos_minclock,
   Optional[Integer[1]] $tos_minsane,
   Optional[Integer[1]] $tos_floor,

--- a/metadata.json
+++ b/metadata.json
@@ -99,6 +99,14 @@
         "2014.09",
         "2015.03"
       ]
+    },
+    { "operatingsystem": "FreeBSD",
+      "operatingsystemrelease": [
+        "9",
+        "10",
+        "11",
+        "12"
+      ]
     }
   ],
   "requirements": [

--- a/templates/ntp.conf.epp
+++ b/templates/ntp.conf.epp
@@ -105,7 +105,7 @@ leapfile <%= $ntp::leapfile %>
 <% } -%>
 
 <% if $ntp::tos {-%>
-tos <% if $ntp::tos_minclock {-%> minclock <%= $ntp::tos_minclock %><% } %><% if $ntp::tos_minsane {-%> minsane <%= $ntp::tos_minsane %><% } %><% if $ntp::tos_floor {-%> floor <%= $ntp::tos_floor %><% } %><% if $ntp::tos_ceiling {-%> ceiling <%= $ntp::tos_ceiling %><% } %><% if $ntp::tos_cohort {-%> cohort <%= $ntp::tos_cohort %><% } %>
+tos <% if $ntp::tos_minclock {-%> minclock <%= $ntp::tos_minclock %><% } %> <% if $ntp::tos_maxclock {-%> maxclock <%= $ntp::tos_maxclock %><% } %> <% if $ntp::tos_minsane {-%> minsane <%= $ntp::tos_minsane %><% } %> <% if $ntp::tos_floor {-%> floor <%= $ntp::tos_floor %><% } %> <% if $ntp::tos_ceiling {-%> ceiling <%= $ntp::tos_ceiling %><% } %> <% if $ntp::tos_cohort {-%> cohort <%= $ntp::tos_cohort %><% } %>
 <% } %>
 
 <% if $ntp::authprov {-%>


### PR DESCRIPTION
1) Lack of spaces between params causes an error in tos string:

~~~
Jan  7 22:16:41 gizmo ntpd[76017]: line 43 column 9 syntax error, unexpected T_String, expecting T_Double or T_Integer
Jan  7 22:16:41 gizmo ntpd[76017]: syntax error in /etc/ntp.conf line 43, column 9
~~~

where 43 string is:
~~~
tos minclock 3minsane 1floor 1ceiling 15cohort 0
~~~

2) add missed maxclock params
3) tested on FreeBSD platform 9,10,11,12 (aka HEAD/current).
