### PR TITLE
SUSE drift file location corrected

### DIFF
--- a/data/Suse.yaml
+++ b/data/Suse.yaml
@@ -1,4 +1,5 @@
 ntp::service_name: ntp
+ntp::driftfile: '/var/lib/ntp/drift/ntp.drift'
 ntp::restrict:
   - 'default kod nomodify notrap nopeer noquery'
   - '-6 default kod nomodify notrap nopeer noquery'


### PR DESCRIPTION
On the SUSE platform the directory `/var/lib/ntp` is not writable by the ntp process, the drift file should be `/var/lib/ntp/drift/ntp.drift` (verified with OpenSUSE 13.2, 42.2 and SLES 12 SP2).