### PR TITLE
(MODULES-3396) remove superfluous empty lines in ntp.conf

### DIFF
--- a/templates/ntp.conf.epp
+++ b/templates/ntp.conf.epp
@@ -1,13 +1,13 @@
 # ntp.conf: Managed by puppet.
 #
+<% if $ntp::_tinker and ($ntp::_panic or $ntp::stepout) {-%>
 # Enable next tinker options:
 # panic - keep ntpd from panicking in the event of a large clock skew
 # when a VM guest is suspended and resumed;
 # stepout - allow ntpd change offset faster
-<% if $ntp::_tinker and ($ntp::_panic or $ntp::stepout) {-%>
 tinker<% if $ntp::_panic { %> panic <%= $ntp::_panic %><% } %><%if $ntp::stepout { %> stepout <%=$ntp::stepout %><% } %>
 <% } -%>
-
+<%# -%>
 <% if $ntp::disable_monitor {-%>
 disable monitor
 <% } else {-%>
@@ -27,17 +27,19 @@ disable auth
 <% if $ntp::disable_kernel {-%>
 disable kernel
 <% } -%>
-
+<%# -%>
 <% unless $ntp::restrict.empty {-%>
+
 # Permit time synchronization with our time source, but do not
 # permit the source to query or modify the service on this system.
 <% $ntp::restrict.each |$restrict| {-%>
 restrict <%= $restrict %>
 <% } -%>
 <% } -%>
-
+<%# -%>
 <% unless $ntp::interfaces.empty {-%>
 <% if $ntp::interfaces_ignore.empty {-%>
+
 # Ignore wildcard interface and only listen on the following specified
 # interfaces
 interface ignore wildcard
@@ -50,7 +52,7 @@ interface ignore <%= $interface %>
 interface listen <%= $interface %>
 <% } -%>
 <% } -%>
-
+<%# -%>
 <% if $ntp::broadcastclient {-%>
 broadcastclient
 <% } -%>
@@ -64,8 +66,9 @@ broadcastclient
 <% $ntp::servers.each |$server| {-%>
 server <%= $server %><% if $ntp::iburst_enable == true {%> iburst<% } %><% if ($ntp::preferred_servers).member($server) { %> prefer<% } %><% if $ntp::minpoll { %> minpoll <%= $ntp::minpoll %><% } %><% if $ntp::maxpoll { %> maxpoll <%= $ntp::maxpoll %><% } %>
 <% } -%>
-
+<%# -%>
 <% if $ntp::udlc {-%>
+
 # Undisciplined Local Clock. This is a fake driver intended for backup
 # and when no outside source of synchronized time is available.
 server   127.127.1.0
@@ -75,32 +78,34 @@ restrict 127.127.1.0
 
 # Driftfile.
 driftfile <%= $ntp::driftfile %>
-
+<%# -%>
 <% if $ntp::logfile {-%>
+
 # Logfile
 logfile <%= $ntp::logfile %>
 <% } -%>
-
+<%# -%>
 <% if $ntp::ntpsigndsocket {-%>
+
 # Enable signed packets
 ntpsigndsocket <%= $ntp::ntpsigndsocket %>
 <% } -%>
-
+<%# -%>
 <% unless $ntp::peers.empty {-%>
+
 # Peers
 <% $ntp::peers.each |$peer| {-%>
 peer <%= $peer %>
 <% } -%>
 <% } -%>
-
 <% unless $ntp::pool.empty {-%>
+
 # Pool
 <% $ntp::pool.each |$pool_srv| {-%>
 pool <%= $pool_srv %>
 <% } -%>
 <% } -%>
-
-
+<%# -%>
 <% if $ntp::keys_enable {-%>
 keys <%= $ntp::keys_file %>
 <% unless $ntp::keys_trusted.empty {-%>
@@ -116,16 +121,17 @@ controlkey <%= $ntp::keys_controlkey %>
 <% $ntp::fudge.each |$entry| {-%>
 fudge <%= $entry %>
 <% } -%>
-
+<%# -%>
 <% if $ntp::leapfile {-%>
+
 # Leapfile
 leapfile <%= $ntp::leapfile %>
 <% } -%>
-
+<%# -%>
 <% if $ntp::tos {-%>
 tos <% if $ntp::tos_minclock {-%> minclock <%= $ntp::tos_minclock %><% } %><% if $ntp::tos_minsane {-%> minsane <%= $ntp::tos_minsane %><% } %><% if $ntp::tos_floor {-%> floor <%= $ntp::tos_floor %><% } %><% if $ntp::tos_ceiling {-%> ceiling <%= $ntp::tos_ceiling %><% } %><% if $ntp::tos_cohort {-%> cohort <%= $ntp::tos_cohort %><% } %>
 <% } %>
-
+<%# -%>
 <% if $ntp::authprov {-%>
 authprov <%= $ntp::authprov %>
 <% } -%>


### PR DESCRIPTION
prior to this commit each new attribute added to the template was adding an empty line, causing restart and unnecessary service disruption