### PR TITLE
Remove anchor comment

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -119,10 +119,6 @@ class ntp (
     $_panic  = $panic
   }
 
-  # Anchor this as per #8040 - this ensures that classes won't float off and
-  # mess everything up.  You can read about this at:
-  # http://docs.puppetlabs.com/puppet/2.7/reference/lang_containment.html#known-issues
-
   contain ntp::install
   contain ntp::config
   contain ntp::service


### PR DESCRIPTION
This has been made obsolete in puppet 4, and the comment is a left-over from when the `anchor` resources were removed.