### PR TITLE
Update permissions on the keys file

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -26,7 +26,7 @@ class ntp::config inherits ntp {
       ensure  => file,
       owner   => 0,
       group   => 0,
-      mode    => '0644',
+      mode    => '0600',
       content => template('ntp/keys.erb'),
     }
   }


### PR DESCRIPTION
Permissions on the keys file should not be group or world-readable since it contains auth information; this patch sets the permissions to 600 vice 644. I didn't see any unit tests that this broke, but I'd be happy to update one if it did.