### PR TITLE
Adjust for openSUSE Leap and other newer openSUSE releases

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -173,18 +173,9 @@ class ntp::params {
         }
         'OpenSuSE': {
           $service_provider = undef
-          case $::operatingsystemrelease {
-            '13.2': {
-              $service_name  = 'ntpd'
-              $keys_file     = $default_keys_file
-              $package_name  = $default_package_name
-            }
-            default: {
-              $service_name  = 'ntp'
-              $keys_file     = $default_keys_file
-              $package_name  = $default_package_name
-            }
-          }
+          $service_name  = 'ntpd'
+          $keys_file     = $default_keys_file
+          $package_name  = $default_package_name
         }
         default: {
           $service_name  = 'ntp'


### PR DESCRIPTION
Starting with openSUSE 13.2 the ntp service was renamed to "ntpd".

Since openSUSE 13.2 is already out of regular maintenance and older
releases are even more so, simplify the whole logic by only handling
the case for 13.2 and newer releases, which consistently use "ntpd",
and so the case for "ntp" (which was only there for older releases,
but matched for newer releases as well) can be removed alltogether.