### PR TITLE
Removing an extra quote from the README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -477,7 +477,7 @@ Data type: String.
 
 Which service provider to use for NTP.
 
-Default value: '`undef`.
+Default value: `undef`.
 
 #### `statistics`
 


### PR DESCRIPTION
Removing an extra single quote mark in the README file.