### PR TITLE
Update ntp.conf.epp

### DIFF
--- a/templates/ntp.conf.epp
+++ b/templates/ntp.conf.epp
@@ -130,7 +130,7 @@ leapfile <%= $ntp::leapfile %>
 <% } -%>
 <%# -%>
 <% if $ntp::tos {-%>
-tos <% if $ntp::tos_minclock {-%> minclock <%= $ntp::tos_minclock %><% } %><% if $ntp::tos_minsane {-%> minsane <%= $ntp::tos_minsane %><% } %><% if $ntp::tos_floor {-%> floor <%= $ntp::tos_floor %><% } %><% if $ntp::tos_ceiling {-%> ceiling <%= $ntp::tos_ceiling %><% } %><% if $ntp::tos_cohort {-%> cohort <%= $ntp::tos_cohort %><% } %>
+tos <% if $ntp::tos_minclock {-%> minclock <%= $ntp::tos_minclock %><% } %> <% if $ntp::tos_minsane {-%> minsane <%= $ntp::tos_minsane %> <% } %><% if $ntp::tos_floor {-%> floor <%= $ntp::tos_floor %><% } %> <% if $ntp::tos_ceiling {-%> ceiling <%= $ntp::tos_ceiling %><% } %> <% if $ntp::tos_cohort {-%> cohort <%= $ntp::tos_cohort %><% } %>
 <% } %>
 <%# -%>
 <% if $ntp::authprov {-%>


### PR DESCRIPTION
When using multiple aruguments for tos option there was a whitespace missing between an argument value and a next argument keyword. As a result ntp service is not configured as expected and systemctl status ntpd will return errors.

So after this commit we should se this diff when running puppet agent -t:
-tos minclock 4minsane 4floor ...
+tos minclock 4 minsane 4 floor ...

Regards,
Bart