### PR TITLE
allow monitor disabled while setting stat properties

### DIFF
--- a/templates/ntp.conf.epp
+++ b/templates/ntp.conf.epp
@@ -10,7 +10,8 @@ tinker<% if $ntp::_panic { %> panic <%= $ntp::_panic %><% } %><%if $ntp::stepout
 <%# -%>
 <% if $ntp::disable_monitor {-%>
 disable monitor
-<% } else {-%>
+<% } -%>
+
 statsdir <%= $ntp::statsdir %>
 <% unless $ntp::statistics.empty {-%>
 # Build requested statistics files
@@ -19,7 +20,6 @@ statistics <%= $ntp::statistics.join(' ') %>
 filegen <%= $statistic %> file <%= $statistic %> type day enable
 <% } -%>
 
-<% } -%>
 <% } -%>
 <% if $ntp::disable_auth {-%>
 disable auth


### PR DESCRIPTION
theres nothing stopping stats with 'disable monitor' from working, not sure why stats were dependent on monitor.

This is working as expected on my end, if theres some internal NTP property that this is in conflict with could you please let me know.