### PR TITLE
Update yaml to version 5

### DIFF
--- a/hiera.yaml
+++ b/hiera.yaml
@@ -1,22 +1,22 @@
 ---
-version: 4
-datadir: data
+version: 5
+
+defaults:
+  datadir: 'data'
+  data_hash: 'yaml_data'
+
 hierarchy:
-  - name: "Full Version"
-    backend: yaml
-    path: "%{facts.os.name}-%{facts.os.release.full}"
+  - name: 'Full Version'
+    path: '%{facts.os.name}-%{facts.os.release.full}.yaml'
 
-  - name: "Major Version"
-    backend: yaml
-    path: "%{facts.os.name}-%{facts.os.release.major}"
+  - name: 'Major Version'
+    path: '%{facts.os.name}-%{facts.os.release.major}.yaml'
 
-  - name: "Distribution Name"
-    backend: yaml
-    path: "%{facts.os.name}"
+  - name: 'Distribution Name'
+    path: '%{facts.os.name}.yaml'
 
-  - name: "Operating System Family"
-    backend: yaml
-    path: "%{facts.os.family}"
+  - name: 'Operating System Family'
+    path: '%{facts.os.family}.yaml'
 
-  - name: "common"
-    backend: yaml
+  - name: 'common'
+    path: 'common.yaml'

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,6 @@
   "dependencies": [
     { "name":"puppetlabs/stdlib","version_requirement":">= 4.13.1 < 5.0.0" }
   ],
-  "data_provider": "hiera",
   "operatingsystem_support": [
     {
       "operatingsystem": "RedHat",


### PR DESCRIPTION
This change updates the hiera.yaml to version 5 and removes all complaints about this package from puppet version 4.10 runs.