### PR TITLE
[MODULES-4941] Correct driftfile for SUSE OS

### DIFF
--- a/data/Suse.yaml
+++ b/data/Suse.yaml
@@ -1,4 +1,5 @@
 ntp::service_name: ntp
+ntp::driftfile: '/var/lib/ntp/drift/ntp.drift'
 ntp::restrict:
   - 'default kod nomodify notrap nopeer noquery'
   - '-6 default kod nomodify notrap nopeer noquery'


### PR DESCRIPTION
The default location for the ntp driftfile on SUSE is
  /var/lib/ntp/drift/ntp.drift

therefore /var/lib/ntp/drift is a directory, and the driftfile
is not created. This commit changes the location of the driftfile
for SUSE to the default location.