### PR TITLE
(MODULES-4168) Add option to enable NTP mode7

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,14 @@ Specifies the location of the NTP driftfile.
 
 Default value: '/var/lib/ntp/drift' (AIX: 'ntp::driftfile:', Solaris: '/var/ntp/ntp.drift').
 
+#### `enable_mode7`
+
+Data type: Boolean.
+
+Enables processing of NTP mode 7 implementation-specific requests which are used by the deprecated ntpdc program.
+
+Default value: `false`.
+
 #### `fudge`
 
 Optional.

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -11,6 +11,7 @@ ntp::disable_dhclient: false
 ntp::disable_kernel: false
 ntp::disable_monitor: true
 ntp::driftfile: '/var/lib/ntp/drift'
+ntp::enable_mode7: false
 ntp::fudge: []
 ntp::iburst_enable: true
 ntp::interfaces_ignore: []

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,6 +14,7 @@
 # @param disable_kernel [Boolean] Disables kernel time discipline.
 # @param disable_monitor [Boolean] Disables the monitoring facility in NTP. Default value: true.
 # @param driftfile [Stdlib::Absolutepath] Specifies an NTP driftfile. Default value: '/var/lib/ntp/drift' (except on AIX and Solaris).
+# @param enable_mode7 [Boolean] Enables processing of NTP mode 7 implementation-specific requests which are used by the deprecated ntpdc program. Default value: false.
 # @param fudge [Optional. Array[String]]. Provides additional information for individual clock drivers. Default value: [ ]
 # @param iburst_enable [Boolean] Specifies whether to enable the iburst option for every NTP peer. Default value: false (true on AIX and Debian).
 # @param interfaces [Array[String]]. Specifies one or more network interfaces for NTP to listen on. Default value: [ ].
@@ -70,6 +71,7 @@ class ntp (
   Boolean $disable_dhclient,
   Boolean $disable_kernel,
   Boolean $disable_monitor,
+  Boolean $enable_mode7,
   Optional[Array[String]] $fudge,
   Stdlib::Absolutepath $driftfile,
   Optional[Stdlib::Absolutepath] $leapfile,

--- a/spec/acceptance/enable_mode7_spec.rb
+++ b/spec/acceptance/enable_mode7_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper_acceptance'
+
+if (fact('osfamily') == 'Solaris')
+  config = '/etc/inet/ntp.conf'
+else
+  config = '/etc/ntp.conf'
+end
+
+describe "ntp class with enable_mode7:", :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamily')) do
+  context 'should enable' do
+    pp = "class { 'ntp': enable_mode7 => true }"
+
+    it 'runs twice' do
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_changes => true)
+    end
+
+    describe file("#{config}") do
+      its(:content) { should match('enable mode7') }
+    end
+  end
+
+  context 'should not enable' do
+    pp = "class { 'ntp': enable_mode7 => false }"
+
+    it 'runs twice' do
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_changes => true)
+    end
+
+    describe file("#{config}") do
+      its(:content) { should_not match('enable mode7') }
+    end
+  end
+
+end

--- a/spec/classes/ntp_spec.rb
+++ b/spec/classes/ntp_spec.rb
@@ -281,6 +281,40 @@ describe 'ntp' do
             end
           end
         end
+        describe 'with parameter enable_mode7' do
+          context 'default' do
+            let(:params) {{
+            }}
+
+            it 'should not contain enable mode7 setting' do
+              should_not contain_file('/etc/ntp.conf').with({
+                'content' => /^enable mode7\n/,
+              })
+            end
+          end
+          context 'when set to true' do
+            let(:params) {{
+              :enable_mode7=> true,
+            }}
+
+            it 'should contain enable mode7 setting' do
+              should contain_file('/etc/ntp.conf').with({
+                'content' => /^enable mode7\n/,
+              })
+            end
+          end
+          context 'when set to false' do
+            let(:params) {{
+              :enable_mode7 => false,
+            }}
+
+            it 'should not contain enable mode7 setting' do
+              should_not contain_file('/etc/ntp.conf').with({
+                'content' => /^enable mode7\n/,
+              })
+            end
+          end
+        end
         describe 'with parameter broadcastclient' do
           context 'when set to true' do
             let(:params) {{

--- a/templates/ntp.conf.epp
+++ b/templates/ntp.conf.epp
@@ -27,6 +27,9 @@ disable auth
 <% if $ntp::disable_kernel {-%>
 disable kernel
 <% } -%>
+<% if $ntp::enable_mode7 {-%>
+enable mode7
+<% } -%>
 <%# -%>
 <% unless $ntp::restrict.empty {-%>
 


### PR DESCRIPTION
This change allows to enable NTP mode7, which is used by the deprecated ntpdc program, but is also used by the colltectd plugin ntp. Mode7 was disabled by default starting with ntp 4.2.8.
The default behavior is not changed.