### PR TITLE
Change type range to match documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ Optional.
 
 Data type: Ntp::Poll_interval.
 
-Sets Puppet to non-standard minimal poll interval of upstream servers. Values: 3 to 16.
+Sets Puppet to non-standard minimal poll interval of upstream servers. Values: 4 to 16.
 Default: `undef`.
 
 #### `maxpoll`
@@ -352,7 +352,7 @@ Optional.
 
 Data type: Ntp::Poll_interval.
 
-Sets use non-standard maximal poll interval of upstream servers. Values: 3 to 16.
+Sets use non-standard maximal poll interval of upstream servers. Values: 5 to 17.
 Default option: `undef`(FreeBSD: 9).
 
 #### `ntpsigndsocket`

--- a/types/poll_interval.pp
+++ b/types/poll_interval.pp
@@ -1,3 +1,3 @@
 # See http://doc.ntp.org/4.2.6/clockopt.html#server for documentation
 # Alternatively: type Ntp::Poll_interval = Variant[Integer, Pattern['']]
-type Ntp::Poll_interval = Integer[4, 17]
+type Ntp::Poll_interval = Integer[3, 17]

--- a/types/poll_interval.pp
+++ b/types/poll_interval.pp
@@ -1,3 +1,3 @@
 # See http://doc.ntp.org/4.2.6/clockopt.html#server for documentation
 # Alternatively: type Ntp::Poll_interval = Variant[Integer, Pattern['']]
-type Ntp::Poll_interval = Integer[3, 17]
+type Ntp::Poll_interval = Integer[4, 17]


### PR DESCRIPTION
Documentation mentions the supported range for minpoll/maxpoll is 3 to 17.  Type was limiting it to 4 to 17.