### PR TITLE
MODULES-5775 update puppet version requirement

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -101,7 +101,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.7.0 < 6.0.0"
+      "version_requirement": ">= 4.9.0 < 6.0.0"
     }
   ],
   "description": "NTP Module for Debian, Ubuntu, CentOS, RHEL, OEL, Fedora, FreeBSD, ArchLinux, Amazon Linux and Gentoo."


### PR DESCRIPTION
since hiera 5 is used the minimum puppet version should be 4.9