### PR TITLE
(MODULES-5831) - Release Prep for NTP 7.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org).
 
+## Supported Release 7.0.0
+### Summary
+Hiera 5 only works with Puppet 4.9.4 and above, we have bumped the Puppet requirement for the module accordingly.
+
+### Changed
+- Update YAML to version 5 ([PR 428](https://github.com/puppetlabs/puppetlabs-ntp/pull/428))
+- Updates the lower puppet version boundary to 4.9.4.
+
 ## Supported Release 6.4.1
 ### Summary
 This release reverts a PR that implements Hiera 5. Issues have been seen due to compatibility issues. The issues that have been seen are ([MODULES-5775](https://tickets.puppet.com/browse/MODULES-5775)) and ([MODULES-5780](https://tickets.puppet.com/browse/MODULES-5780)).

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-ntp",
-  "version": "6.4.1",
+  "version": "7.0.0",
   "author": "Puppet Inc",
   "summary": "Installs, configures, and manages the NTP service.",
   "license": "Apache-2.0",
@@ -101,7 +101,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.7.0 < 6.0.0"
+      "version_requirement": ">= 4.9.4 < 6.0.0"
     }
   ],
   "description": "NTP Module for Debian, Ubuntu, CentOS, RHEL, OEL, Fedora, FreeBSD, ArchLinux, Amazon Linux and Gentoo."


### PR DESCRIPTION
This is a major version bump as the lower puppet version boundary has
been updated to 4.9.4. The reasoning for this is that Hiera 5 needs a
minimum puppet version of 4.9.4.