### PR TITLE
Don't use 'inherits' in config, install and service

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,6 +1,6 @@
 # @api private
 # This class handles the configuration file. Avoid modifying private classes.
-class ntp::config inherits ntp {
+class ntp::config {
 
   #The servers-netconfig file overrides NTP config on SLES 12, interfering with our configuration.
   if ($facts['operatingsystem'] == 'SLES' and $facts['operatingsystemmajrelease'] == '12') or

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,6 +1,6 @@
-# @api private 
+# @api private
 # This class handles ntp packages. Avoid modifying private classes.
-class ntp::install inherits ntp {
+class ntp::install {
 
   if $ntp::package_manage {
 

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,6 +1,6 @@
 # @api private
 # This class handles the ntp service. Avoid modifying private classes.
-class ntp::service inherits ntp {
+class ntp::service {
 
   if $ntp::service_manage == true {
     service { 'ntp':


### PR DESCRIPTION
Since the ntp class contains the other ntp classes ntp::config,
ntp::install and ntp::service it is neither necessary nor useful for
these classes to inherit from the "main" ntp class.

Letting the classes ntp::config, ntp::install and ntp::service inherit
from ntp is also counter all recommendations in the Puppet
documentation. The puppetlabs-ntp module is widely regarded as a "poster
child" for designing Puppet modules and is often used as reference by
Puppet newcomers. It should not make use of deprecated and useless or
confusing patterns.

See also https://github.com/puppetlabs/puppet-docs/pull/801