### PR TITLE
Add burst param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,6 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org).
 
-### Added
-- `burst` parameter (defaults to `false`)
-
 ## [7.2.0](https://github.com/puppetlabs/puppetlabs-ntp/tree/7.2.0) (2018-07-03)
 
 [Full Changelog](https://github.com/puppetlabs/puppetlabs-ntp/compare/7.1.1...7.2.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org).
 
+### Added
+- `burst` parameter (defaults to `false`)
+
 ## [7.2.0](https://github.com/puppetlabs/puppetlabs-ntp/tree/7.2.0) (2018-07-03)
 
 [Full Changelog](https://github.com/puppetlabs/puppetlabs-ntp/compare/7.1.1...7.2.0)

--- a/README.md
+++ b/README.md
@@ -110,6 +110,15 @@ class { 'ntp':
 }
 ```
 
+### Connect to an NTP server with the burst option enabled
+
+```puppet
+class { 'ntp':
+  servers => [ 'ntp1.corp.com', 'ntp2.corp.com' ],
+  burst  => true,
+}
+```
+
 ## Reference
 
 See [REFERENCE.md](REFERENCE.md)

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,6 +1,7 @@
 ---
 ntp::authprov: ~
 ntp::broadcastclient: false
+ntp::burst: false
 ntp::config_dir: ~
 ntp::config_file_mode: '0644'
 ntp::config: '/etc/ntp.conf'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,6 +8,9 @@
 # @param broadcastclient
 #   Enables reception of broadcast server messages to any local interface. Default value: false.
 #
+# @param burst
+#   When the server is reachable, send a burst of eight packets instead of the usual one. Default value: false.
+#
 # @param config
 #   Specifies a file for NTP's configuration info. Default value: '/etc/ntp.conf' (or '/etc/inet/ntp.conf' on Solaris).
 #
@@ -52,7 +55,7 @@
 # @param interfaces
 #   Specifies one or more network interfaces for NTP to listen on. Default value: [ ].
 #
-# @param interfaces_ignore 
+# @param interfaces_ignore
 #   Specifies one or more ignore pattern for the NTP listener configuration (for example: all, wildcard, ipv6). Default value: [ ].
 #
 # @param keys
@@ -151,7 +154,7 @@
 #   Which service provider to use for NTP. Default value: 'undef'.
 #
 # @param slewalways
-#   xntpd setting to disable stepping behavior and always slew the clock to handle adjustments. 
+#   xntpd setting to disable stepping behavior and always slew the clock to handle adjustments.
 #   Only relevant for AIX. Default value: 'undef'. Allowed values: 'yes', 'no'
 #
 # @param statistics
@@ -208,6 +211,7 @@
 #
 class ntp (
   Boolean $broadcastclient,
+  Boolean $burst,
   Stdlib::Absolutepath $config,
   Optional[Stdlib::Absolutepath] $config_dir,
   String $config_file_mode,

--- a/spec/classes/ntp_spec.rb
+++ b/spec/classes/ntp_spec.rb
@@ -395,6 +395,32 @@ on_supported_os.reject { |_, f| f[:os]['family'] == 'Solaris' }.each do |os, f|
           end
         end
 
+        describe 'with parameter burst' do
+          context 'when set to true' do
+            let(:params) do
+              {
+                burst: true,
+              }
+            end
+
+            it do
+              is_expected.to contain_file('/etc/ntp.conf').with('content' => %r{ burst\n})
+            end
+          end
+
+          context 'when set to false' do
+            let(:params) do
+              {
+                burst: false,
+              }
+            end
+
+            it do
+              is_expected.not_to contain_file('/etc/ntp.conf').with('content' => %r{ burst\n})
+            end
+          end
+        end
+
         context 'when choosing the default pool servers' do
           case f[:os]['family']
           when 'RedHat'

--- a/templates/ntp.conf.epp
+++ b/templates/ntp.conf.epp
@@ -62,13 +62,14 @@ broadcastclient
 
 # Set up servers for ntpd with next options:
 # server - IP address or DNS name of upstream NTP server
+# burst - send a burst of eight packets instead of the usual one.
 # iburst - allow send sync packages faster if upstream unavailable
 # prefer - select preferrable server
 # minpoll - set minimal update frequency
 # maxpoll - set maximal update frequency
 # noselect - do not sync with this server
 <% $ntp::servers.each |$server| {-%>
-server <%= $server %><% if $ntp::iburst_enable == true {%> iburst<% } %><% if ($ntp::preferred_servers).member($server) { %> prefer<% } %><% if $ntp::minpoll { %> minpoll <%= $ntp::minpoll %><% } %><% if $ntp::maxpoll { %> maxpoll <%= $ntp::maxpoll %><% } %><% if ($ntp::noselect_servers).member($server) { %> noselect<% } %>
+server <%= $server %><% if $ntp::iburst_enable == true {%> iburst<% } %><% if ($ntp::preferred_servers).member($server) { %> prefer<% } %><% if $ntp::burst == true {%> burst<% } %><% if $ntp::minpoll { %> minpoll <%= $ntp::minpoll %><% } %><% if $ntp::maxpoll { %> maxpoll <%= $ntp::maxpoll %><% } %><% if ($ntp::noselect_servers).member($server) { %> noselect<% } %>
 <% } -%>
 <%# -%>
 <% if $ntp::udlc {-%>


### PR DESCRIPTION
[https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html/deployment_guide/s2_configuring_the_burst_option](url)

22.16.10. CONFIGURING THE BURST OPTION
Using the burst option against a public server is considered abuse. Do not use this option with public NTP servers. Use it only for applications within your own organization.
To increase the average quality of time offset statistics, add the following option to the end of a server command:
burst
At every poll interval, when the server responds, the system will send a burst of up to eight packets instead of the usual one packet. For use with the server command to improve the average quality of the time-offset calculations.