### PR TITLE
Fix forge link to reference.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ class { 'ntp':
 
 ## Reference
 
-See [REFERENCE.md](REFERENCE.md)
+See [REFERENCE.md](https://github.com/puppetlabs/puppetlabs-ntp/blob/master/REFERENCE.md)
 
 ## Limitations
 


### PR DESCRIPTION
In order for the link on the forge site to work for the reference.md file you must specify the absolute github url as the link.  This fixes that.