### PR TITLE
Service hasstatus and hasrestart atributes

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -47,6 +47,8 @@ ntp::service_ensure: running
 ntp::service_manage: true
 ntp::service_name: ntpd
 ntp::service_provider: ~
+ntp::service_hasstatus: true
+ntp::service_hasrestart: true
 ntp::slewalways: ~
 ntp::statistics: []
 ntp::statsdir: '/var/log/ntpstats'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -156,6 +156,12 @@
 # @param service_provider
 #   Which service provider to use for NTP. Default value: 'undef'.
 #
+# @param service_hasstatus
+#   Whether service has a functional status command. Default value: true.
+#
+# @param service_hasrestart
+#   Whether service has a restart command. Default value: true.
+#
 # @param slewalways
 #   xntpd setting to disable stepping behavior and always slew the clock to handle adjustments.
 #   Only relevant for AIX. Default value: 'undef'. Allowed values: 'yes', 'no'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -262,6 +262,8 @@ class ntp (
   Boolean $service_manage,
   String $service_name,
   Optional[String] $service_provider,
+  Boolean $service_hasstatus,
+  Boolean $service_hasrestart,
   Optional[Enum['yes','no']] $slewalways,
   Optional[Array] $statistics,
   Optional[Stdlib::Absolutepath] $statsdir,

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -11,8 +11,8 @@ class ntp::service {
       enable     => $ntp::service_enable,
       name       => $ntp::service_name,
       provider   => $ntp::service_provider,
-      hasstatus  => true,
-      hasrestart => true,
+      hasstatus  => $ntp::service_hasstatus,
+      hasrestart => $ntp::service_hasrestart,
     }
   }
 

--- a/spec/classes/ntp_spec.rb
+++ b/spec/classes/ntp_spec.rb
@@ -542,6 +542,8 @@ on_supported_os.reject { |_, f| f[:os]['family'] == 'Solaris' }.each do |os, f|
               enable: true,
               ensure: 'running',
               name: 'ntp',
+              hasstatus: true,
+              hasrestart: true,
             )
           }
         end
@@ -551,6 +553,22 @@ on_supported_os.reject { |_, f| f[:os]['family'] == 'Solaris' }.each do |os, f|
             let(:params) { { service_name: 'ntp', service_ensure: 'stopped' } }
 
             it { is_expected.to contain_service('ntp').with_ensure('stopped') }
+          end
+        end
+
+        describe 'service_hasstatus' do
+          describe 'when overridden' do
+            let(:params) { { service_name: 'ntp', service_hasstatus: false } }
+
+            it { is_expected.to contain_service('ntp').with_hasstatus(false) }
+          end
+        end
+
+        describe 'service_hasrestart' do
+          describe 'when overridden' do
+            let(:params) { { service_name: 'ntp', service_hasrestart: false } }
+
+            it { is_expected.to contain_service('ntp').with_hasrestart(false) }
           end
         end
 


### PR DESCRIPTION
Hi, this is my first pull request to this project. Let me know any changes that I need to do.

This PR adds class parameters to modify service hasstatus and hasrestart atributes, that are currently fixed to true.
Motivation of this change is that under some circumstances, a service restarts fails as if ntp process was slowly to stop, and the new one starting can't bind to address / port.

```
puppet-agent[28907]: (/Stage[main]/Ntp::Config/File[/etc/ntp.conf]/content) content changed '{md5}401589661b64e90b77c9c7f3f6a88df8' to '{md5}d79f2e85f4b263535186c092f99ed5ff'
 systemd[1]: Stopping LSB: Start NTP daemon...
 ntp[29587]:  * Stopping NTP server ntpd
 ntp[29587]:    ...done.
 systemd[1]: Stopped LSB: Start NTP daemon.
 systemd[1]: Starting LSB: Start NTP daemon...
 ntp[29600]:  * Starting NTP server ntpd
 ntpd[29608]: ntpd 4.2.8p4@1.3265-o Fri Jul  6 20:10:51 UTC 2018 (1): Starting
 ntpd[29608]: Command line: /usr/sbin/ntpd -p /var/run/ntpd.pid -g -u 112:121
 ntp[29600]:    ...done.
 systemd[1]: Started LSB: Start NTP daemon.
 puppet-agent[28907]: (/Stage[main]/Ntp::Service/Service[ntp]) Triggered 'refresh' from 1 event
 ntpd[29611]: proto: precision = 0.052 usec (-24)
 ntpd[29611]: restrict default: KOD does nothing without LIMITED.
 ntpd[29611]: restrict ::: KOD does nothing without LIMITED.
 ntpd[29611]: unable to bind to wildcard address :: - another process may be running - EXITING
 ntpd[8066]: ntpd exiting on signal 15 (Terminated)
```