### PR TITLE
Set the path of FreeBSD's leapfile

### DIFF
--- a/data/FreeBSD-family.yaml
+++ b/data/FreeBSD-family.yaml
@@ -1,4 +1,5 @@
 ntp::driftfile: '/var/db/ntpd.drift'
+ntp::leapfile: '/var/db/ntpd.leap-seconds.list'
 ntp::package_name: ['net/ntp']
 ntp::restrict:
   - 'default kod nomodify notrap nopeer noquery'


### PR DESCRIPTION
FreeBSD ships a leapfile that the default configuration of the module can use.

All supported FreeBSD versions contain this file.