### PR TITLE
forced facter 3.9 to ensure AIX testing occurs

### DIFF
--- a/spec/classes/ntp_spec.rb
+++ b/spec/classes/ntp_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-on_supported_os.each do |os, f|
+on_supported_os(facterversion: '3.9.0').each do |os, f|
   describe 'ntp' do
     let(:facts) { { is_virtual: false } }
 
@@ -157,6 +157,10 @@ on_supported_os.each do |os, f|
           when 'Solaris'
             it 'uses the generic NTP pool servers' do
               is_expected.to contain_file('/etc/inet/ntp.conf').with('content' => %r{server \d.pool.ntp.org})
+            end
+          when 'AIX'
+            it 'uses the generic NTP pool servers on AIX' do
+              is_expected.to contain_file('/etc/ntp.conf').with('content' => %r{server \d.pool.ntp.org})
             end
           else
             it {


### PR DESCRIPTION
Because FacterDB does not contain AIX factsets except in 3.2 and 3.9, and PDK loads facter 2.5.1 at the highest, I forced a stub in for AIX support in the spec file for all the resources.

This caused it to fail classifying AIX as an unsupported OS, so I added a test block to cover it.