### PR TITLE
Fix disable_dhclient

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -90,7 +90,7 @@ class ntp::config {
 
   if $ntp::disable_dhclient {
     augeas { 'disable ntp-servers in dhclient.conf':
-      context => '/etc/dhcp/dhclient.conf',
+      context => '/files/etc/dhcp/dhclient.conf',
       changes => 'rm request/*[.="ntp-servers"]',
     }
 


### PR DESCRIPTION
`disable_dhclient` is currently broken due to https://github.com/puppetlabs/puppetlabs-ntp/pull/491/files#r298050592

Two options:
- revert to `/files` in `context` (easier)
- use `incl` + `lens` (a tiny bit more efficient, but more verbose code)