### PR TITLE
Support for illumos

### DIFF
--- a/data/Solaris.yaml
+++ b/data/Solaris.yaml
@@ -1,0 +1,11 @@
+ntp::config: '/etc/inet/ntp.conf'
+ntp::driftfile: '/var/ntp/ntp.drift'
+ntp::keys_file: '/etc/inet/ntp.keys'
+ntp::package_name: [ 'service/network/ntp' ]
+ntp::restrict:
+  - 'default kod nomodify notrap nopeer noquery'
+  - '-6 default kod nomodify notrap nopeer noquery'
+  - '127.0.0.1'
+  - '-6 ::1'
+ntp::service_name: 'network/ntp'
+ntp::iburst_enable: false


### PR DESCRIPTION
This enables support for the [illumos](https://www.illumos.org/) operating system (based on OpenSolaris).

Since the distribution name is at a deeper level in the Hiera hierarchy, it should not interfere with other operating system based on Solaris.