### PR TITLE
(IAC-615) Bump TravisCI test runner dist to bionic

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -2,6 +2,7 @@
 ".gitlab-ci.yml":
   delete: true
 ".travis.yml":
+  dist: 'bionic'
   global_env: 
     - HONEYCOMB_WRITEKEY="7f3c63a70eecc61d635917de46bea4e6",HONEYCOMB_DATASET="litmus tests"
   deploy_to_forge:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 ---
 os: linux
-dist: xenial
+dist: bionic
 language: ruby
 cache: bundler
 before_install:
@@ -16,7 +16,7 @@ script:
   - 'SIMPLECOV=yes bundle exec rake $CHECK'
 bundler_args: --without system_tests
 rvm:
-  - 2.5.3
+  - 2.5.7
 env:
   global:
     - HONEYCOMB_WRITEKEY="7f3c63a70eecc61d635917de46bea4e6",HONEYCOMB_DATASET="litmus tests"
@@ -32,11 +32,10 @@ jobs:
       - "bundle exec rake 'litmus:provision_list[travis_deb]'"
       - "bundle exec rake 'litmus:install_agent[puppet5]'"
       - "bundle exec rake litmus:install_module"
-      bundler_args: 
-      dist: trusty
+      bundler_args:
       env: PLATFORMS=travis_deb_puppet5
-      rvm: 2.5.3
-      script: ["bundle exec rake litmus:acceptance:parallel"]
+      rvm: 2.5.7
+      script: ["travis_wait 45 bundle exec rake litmus:acceptance:parallel"]
       services: docker
       stage: acceptance
     -
@@ -44,11 +43,10 @@ jobs:
       - "bundle exec rake 'litmus:provision_list[travis_ub]'"
       - "bundle exec rake 'litmus:install_agent[puppet5]'"
       - "bundle exec rake litmus:install_module"
-      bundler_args: 
-      dist: trusty
+      bundler_args:
       env: PLATFORMS=travis_ub_puppet5
-      rvm: 2.5.3
-      script: ["bundle exec rake litmus:acceptance:parallel"]
+      rvm: 2.5.7
+      script: ["travis_wait 45 bundle exec rake litmus:acceptance:parallel"]
       services: docker
       stage: acceptance
     -
@@ -56,11 +54,10 @@ jobs:
       - "bundle exec rake 'litmus:provision_list[travis_el6]'"
       - "bundle exec rake 'litmus:install_agent[puppet5]'"
       - "bundle exec rake litmus:install_module"
-      bundler_args: 
-      dist: trusty
+      bundler_args:
       env: PLATFORMS=travis_el6_puppet5
-      rvm: 2.5.3
-      script: ["bundle exec rake litmus:acceptance:parallel"]
+      rvm: 2.5.7
+      script: ["travis_wait 45 bundle exec rake litmus:acceptance:parallel"]
       services: docker
       stage: acceptance
     -
@@ -68,11 +65,10 @@ jobs:
       - "bundle exec rake 'litmus:provision_list[travis_el7]'"
       - "bundle exec rake 'litmus:install_agent[puppet5]'"
       - "bundle exec rake litmus:install_module"
-      bundler_args: 
-      dist: trusty
+      bundler_args:
       env: PLATFORMS=travis_el7_puppet5
-      rvm: 2.5.3
-      script: ["bundle exec rake litmus:acceptance:parallel"]
+      rvm: 2.5.7
+      script: ["travis_wait 45 bundle exec rake litmus:acceptance:parallel"]
       services: docker
       stage: acceptance
     -
@@ -80,11 +76,10 @@ jobs:
       - "bundle exec rake 'litmus:provision_list[travis_deb]'"
       - "bundle exec rake 'litmus:install_agent[puppet6]'"
       - "bundle exec rake litmus:install_module"
-      bundler_args: 
-      dist: trusty
+      bundler_args:
       env: PLATFORMS=travis_deb_puppet6
-      rvm: 2.5.3
-      script: ["bundle exec rake litmus:acceptance:parallel"]
+      rvm: 2.5.7
+      script: ["travis_wait 45 bundle exec rake litmus:acceptance:parallel"]
       services: docker
       stage: acceptance
     -
@@ -92,11 +87,10 @@ jobs:
       - "bundle exec rake 'litmus:provision_list[travis_ub]'"
       - "bundle exec rake 'litmus:install_agent[puppet6]'"
       - "bundle exec rake litmus:install_module"
-      bundler_args: 
-      dist: trusty
+      bundler_args:
       env: PLATFORMS=travis_ub_puppet6
-      rvm: 2.5.3
-      script: ["bundle exec rake litmus:acceptance:parallel"]
+      rvm: 2.5.7
+      script: ["travis_wait 45 bundle exec rake litmus:acceptance:parallel"]
       services: docker
       stage: acceptance
     -
@@ -104,11 +98,10 @@ jobs:
       - "bundle exec rake 'litmus:provision_list[travis_el6]'"
       - "bundle exec rake 'litmus:install_agent[puppet6]'"
       - "bundle exec rake litmus:install_module"
-      bundler_args: 
-      dist: trusty
+      bundler_args:
       env: PLATFORMS=travis_el6_puppet6
-      rvm: 2.5.3
-      script: ["bundle exec rake litmus:acceptance:parallel"]
+      rvm: 2.5.7
+      script: ["travis_wait 45 bundle exec rake litmus:acceptance:parallel"]
       services: docker
       stage: acceptance
     -
@@ -116,11 +109,10 @@ jobs:
       - "bundle exec rake 'litmus:provision_list[travis_el7]'"
       - "bundle exec rake 'litmus:install_agent[puppet6]'"
       - "bundle exec rake litmus:install_module"
-      bundler_args: 
-      dist: trusty
+      bundler_args:
       env: PLATFORMS=travis_el7_puppet6
-      rvm: 2.5.3
-      script: ["bundle exec rake litmus:acceptance:parallel"]
+      rvm: 2.5.7
+      script: ["travis_wait 45 bundle exec rake litmus:acceptance:parallel"]
       services: docker
       stage: acceptance
     -
@@ -132,7 +124,7 @@ jobs:
       stage: spec
     -
       env: PUPPET_GEM_VERSION="~> 6.0" CHECK=parallel_spec
-      rvm: 2.5.3
+      rvm: 2.5.7
       stage: spec
 branches:
   only:

--- a/metadata.json
+++ b/metadata.json
@@ -92,6 +92,6 @@
   ],
   "description": "NTP Module for Debian, Ubuntu, CentOS, RHEL, OEL, Fedora, FreeBSD, ArchLinux, Amazon Linux and Gentoo.",
   "template-url": "https://github.com/puppetlabs/pdk-templates#master",
-  "template-ref": "heads/master-0-g88c96ab",
-  "pdk-version": "1.16.0"
+  "template-ref": "tags/1.17.0-0-gd3a4319",
+  "pdk-version": "1.17.0"
 }


### PR DESCRIPTION
We have struggled to reproduce an issue with tests failing on xenial. A quick solution is to use the Ubuntu `bionic` release instead of `xenial`.