### PR TITLE
(MAINT) Make mode for logfile configurable

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -26,6 +26,7 @@ ntp::keys_trusted: []
 ntp::keys: []
 ntp::leapfile: ~
 ntp::logfile: ~
+ntp::logfile_mode: '0664'
 ntp::logconfig: ~
 ntp::ntpsigndsocket: ~
 ntp::maxpoll: ~

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -141,7 +141,7 @@ class ntp::config {
       ensure => file,
       owner  => 'ntp',
       group  => 'ntp',
-      mode   => '0664',
+      mode   => $ntp::logfile_mode,
     }
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -89,7 +89,7 @@
 #   Specifies a log file for NTP to use instead of syslog. Default value: ' '.
 
 # @param logfile_mode
-#   Specifies the permission fot the NTP log file. Default is 0644.
+#   Specifies the permission fot the NTP log file. Default is 0664.
 #
 # @param logconfig
 #   Specifies the logconfig for NTP to use. Default value: ' '.
@@ -248,7 +248,7 @@ class ntp (
   Stdlib::Absolutepath $driftfile,
   Optional[Stdlib::Absolutepath] $leapfile,
   Optional[Stdlib::Absolutepath] $logfile,
-  Optional[String] $logfile_mode,
+  String $logfile_mode,
   Optional[String] $logconfig,
   Boolean $iburst_enable,
   Array[String] $keys,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -89,7 +89,7 @@
 #   Specifies a log file for NTP to use instead of syslog. Default value: ' '.
 
 # @param logfile_mode
-#   Specifies the permission fot the NTP log file. Default is 0664.
+#   Specifies the permission for the NTP log file. Default is 0664.
 #
 # @param logconfig
 #   Specifies the logconfig for NTP to use. Default value: ' '.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -87,6 +87,9 @@
 #
 # @param logfile
 #   Specifies a log file for NTP to use instead of syslog. Default value: ' '.
+
+# @param logfile_mode
+#   Specifies the permission fot the NTP log file. Default is 0644.
 #
 # @param logconfig
 #   Specifies the logconfig for NTP to use. Default value: ' '.
@@ -245,6 +248,7 @@ class ntp (
   Stdlib::Absolutepath $driftfile,
   Optional[Stdlib::Absolutepath] $leapfile,
   Optional[Stdlib::Absolutepath] $logfile,
+  Optional[String] $logfile_mode,
   Optional[String] $logconfig,
   Boolean $iburst_enable,
   Array[String] $keys,


### PR DESCRIPTION
I need the set custom permissions for the ntp logfile (debian hardening guidelines).
This pull request adds an option to change the default permissions for the logfile