### PR TITLE
(maint) Integration test on gcp

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -5,6 +5,7 @@ fixtures:
     "stdlib": "https://github.com/puppetlabs/puppetlabs-stdlib.git"
     provision: "https://github.com/puppetlabs/provision.git"
     puppet_agent: 'https://github.com/puppetlabs/puppetlabs-puppet_agent.git'
+    package: "https://github.com/puppetlabs/puppetlabs-package.git"
   symlinks:
     "ntp": "#{source_dir}"
     "my_ntp": "#{source_dir}/spec/fixtures/my_ntp"

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -6,6 +6,11 @@ fixtures:
     provision: "https://github.com/puppetlabs/provision.git"
     puppet_agent: 'https://github.com/puppetlabs/puppetlabs-puppet_agent.git'
     package: "https://github.com/puppetlabs/puppetlabs-package.git"
+    deploy_pe: "https://github.com/jarretlavallee/puppet-deploy_pe"
+    sign_cert: "https://github.com/m0dular/sign_cert"
+    ruby_task_helper: "https://git@github.com/puppetlabs/puppetlabs-ruby_task_helper"
+    bootstrap: "https://github.com/puppetlabs/puppetlabs-bootstrap"
+    puppet_conf: "https://github.com/puppetlabs/puppetlabs-puppet_conf"
   symlinks:
     "ntp": "#{source_dir}"
     "my_ntp": "#{source_dir}/spec/fixtures/my_ntp"

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -174,17 +174,17 @@ jobs:
         echo STEP_ID=${{ matrix.platform }}-${{ matrix.collection }}-4 >> $GITHUB_ENV
         echo STEP_START=$(date +%s) >> $GITHUB_ENV
 
-    - name: Remove test environment
-      if: ${{ always() }}
-      continue-on-error: true
-      run: |
-        if [ -f inventory.yaml ]; then
-          buildevents cmd $TRACE_ID $STEP_ID 'rake litmus:tear_down' -- bundle exec rake 'litmus:tear_down'
-          echo ::group::=== REQUEST ===
-          cat request.json || true
-          echo
-          echo ::endgroup::
-        fi
+#    - name: Remove test environment
+#      if: ${{ always() }}
+#      continue-on-error: true
+#      run: |
+#        if [ -f inventory.yaml ]; then
+#          buildevents cmd $TRACE_ID $STEP_ID 'rake litmus:tear_down' -- bundle exec rake 'litmus:tear_down'
+#          echo ::group::=== REQUEST ===
+#          cat request.json || true
+#          echo
+#          echo ::endgroup::
+#        fi
 
     - name: "Honeycomb: Record removal times"
       if: ${{ always() }}

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -55,7 +55,7 @@ jobs:
       id: get-matrix
       run: |
         if [ '${{ github.repository_owner }}' == 'puppetlabs' ]; then
-          buildevents cmd $TRACE_ID $STEP_ID matrix_from_metadata -- bundle exec matrix_from_metadata
+          echo  "::set-output name=matrix::{'platform':['centos-7'],'collection':['puppet6-nightly']}"
         else
           echo  "::set-output name=matrix::{}"
         fi
@@ -126,22 +126,29 @@ jobs:
 
     - name: Provision test environment
       run: |
-        buildevents cmd $TRACE_ID $STEP_ID 'rake litmus:provision ${{ matrix.platform }}' -- bundle exec bolt --modulepath spec/fixtures/modules plan run ntp::provision_gcp gcp_image=${{ matrix.platform }}
+        buildevents cmd $TRACE_ID $STEP_ID 'rake litmus:provision ${{ matrix.platform }}' -- bundle exec bolt --modulepath spec/fixtures/modules plan run ntp::provision_gcp image=${{ matrix.platform }}
         echo ::group::=== REQUEST ===
         cat request.json || true
         echo
         echo ::endgroup::
         echo ::group::=== INVENTORY ===
-        sed -e 's/password: .*/password: "[redacted]"/' < inventory.yaml || true
+        if [ -f 'spec/fixtures/litmus_inventory.yaml' ];
+        then
+          FILE='spec/fixtures/litmus_inventory.yaml'
+        elif [ -f 'inventory.yaml' ];
+        then
+          FILE='inventory.yaml'
+        fi
+        sed -e 's/password: .*/password: "[redacted]"/' < $FILE || true
         echo ::endgroup::
 
-    - name: Install agent
-      uses: nick-invision/retry@v1
-      with:
-        timeout_minutes: 30
-        max_attempts: 5
-        retry_wait_seconds: 60
-        command: buildevents cmd $TRACE_ID $STEP_ID 'rake litmus:install_agent ${{ matrix.collection }}' -- bundle exec rake 'litmus:install_agent[${{ matrix.collection }}]'
+    - name: Install PE
+      run: |
+        bundle exec bolt --modulepath spec/fixtures/modules -i ./spec/fixtures/litmus_inventory.yaml plan run ntp::pe_server
+
+    - name: Install Agents
+      run: |
+        bundle exec bolt --modulepath spec/fixtures/modules -i ./spec/fixtures/litmus_inventory.yaml plan run ntp::pe_agent
 
     - name: Install module
       run: |

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -1,0 +1,185 @@
+name: "Integration Testing"
+
+on: [pull_request]
+
+env:
+  HONEYCOMB_WRITEKEY: 7f3c63a70eecc61d635917de46bea4e6
+  HONEYCOMB_DATASET: litmus tests
+
+jobs:
+  setup_matrix:
+    name: "Setup Test Matrix"
+    runs-on: ubuntu-20.04
+    outputs:
+      matrix: ${{ steps.get-matrix.outputs.matrix }}
+
+    steps:
+    - name: "Honeycomb: Start recording"
+      uses: puppetlabs/kvrhdn-gha-buildevents@pdk-templates-v1
+      with:
+        apikey: ${{ env.HONEYCOMB_WRITEKEY }}
+        dataset: ${{ env.HONEYCOMB_DATASET }}
+        job-status: ${{ job.status }}
+
+    - name: "Honeycomb: Start first step"
+      run: |
+        echo STEP_ID=setup-environment >> $GITHUB_ENV
+        echo STEP_START=$(date +%s) >> $GITHUB_ENV
+
+    - name: Checkout Source
+      uses: actions/checkout@v2
+      if: ${{ github.repository_owner == 'puppetlabs' }}
+
+    - name: Activate Ruby 2.7
+      uses: ruby/setup-ruby@v1
+      if: ${{ github.repository_owner == 'puppetlabs' }}
+      with:
+        ruby-version: "2.7"
+        bundler-cache: true
+
+    - name: Print bundle environment
+      if: ${{ github.repository_owner == 'puppetlabs' }}
+      run: |
+        echo ::group::bundler environment
+        buildevents cmd $TRACE_ID $STEP_ID 'bundle env' -- bundle env
+        echo ::endgroup::
+
+    - name: "Honeycomb: Record Setup Environment time"
+      if: ${{ github.repository_owner == 'puppetlabs' }}
+      run: |
+        buildevents step $TRACE_ID $STEP_ID $STEP_START 'Setup Environment'
+        echo STEP_ID=Setup-Integration-Test-Matrix >> $GITHUB_ENV
+        echo STEP_START=$(date +%s) >> $GITHUB_ENV
+
+    - name: Setup Integration Test Matrix
+      id: get-matrix
+      run: |
+        if [ '${{ github.repository_owner }}' == 'puppetlabs' ]; then
+          buildevents cmd $TRACE_ID $STEP_ID matrix_from_metadata -- bundle exec matrix_from_metadata
+        else
+          echo  "::set-output name=matrix::{}"
+        fi
+
+    - name: "Honeycomb: Record Setup Test Matrix time"
+      if: ${{ always() }}
+      run: |
+        buildevents step $TRACE_ID $STEP_ID $STEP_START 'Setup Test Matrix'
+
+  Integration:
+    needs:
+      - setup_matrix
+    if: ${{ needs.setup_matrix.outputs.matrix != '{}' }}
+
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix: ${{fromJson(needs.setup_matrix.outputs.matrix)}}
+
+    env:
+      BUILDEVENT_FILE: '../buildevents.txt'
+
+    steps:
+    - run: |
+        echo 'platform=${{ matrix.platform }}' >> $BUILDEVENT_FILE
+        echo 'collection=${{ matrix.collection }}' >> $BUILDEVENT_FILE
+
+    - name: "Honeycomb: Start recording"
+      uses: puppetlabs/kvrhdn-gha-buildevents@pdk-templates-v1
+      with:
+        apikey: ${{ env.HONEYCOMB_WRITEKEY }}
+        dataset: ${{ env.HONEYCOMB_DATASET }}
+        job-status: ${{ job.status }}
+        matrix-key: ${{ matrix.platform }}-${{ matrix.collection }}
+
+    - name: "Honeycomb: start first step"
+      run: |
+        echo STEP_ID=${{ matrix.platform }}-${{ matrix.collection }}-1 >> $GITHUB_ENV
+        echo STEP_START=$(date +%s) >> $GITHUB_ENV
+
+    - name: Checkout Source
+      uses: actions/checkout@v2
+
+    - name: Activate Ruby 2.7
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: "2.7"
+        bundler-cache: true
+
+    - name: Print bundle environment
+      run: |
+        echo ::group::bundler environment
+        buildevents cmd $TRACE_ID $STEP_ID 'bundle env' -- bundle env
+        echo ::endgroup::
+
+    - name: Create the fixtures directory
+      run: |
+        echo ::group::Create the fixtures directory
+        buildevents cmd $TRACE_ID $STEP_ID 'bundle exec rake spec_prep' -- bundle exec rake spec_prep
+        echo ::endgroup::
+
+    - name: "Honeycomb: Record Setup Environment time"
+      if: ${{ always() }}
+      run: |
+        buildevents step $TRACE_ID $STEP_ID $STEP_START 'Setup Environment'
+        echo STEP_ID=${{ matrix.platform }}-${{ matrix.collection }}-2 >> $GITHUB_ENV
+        echo STEP_START=$(date +%s) >> $GITHUB_ENV
+
+    - name: Provision test environment
+      run: |
+        buildevents cmd $TRACE_ID $STEP_ID 'rake litmus:provision ${{ matrix.platform }}' -- bundle exec bolt --modulepath spec/fixtures/modules plan run ntp::provision_gcp gcp_image=${{ matrix.platform }}
+        echo ::group::=== REQUEST ===
+        cat request.json || true
+        echo
+        echo ::endgroup::
+        echo ::group::=== INVENTORY ===
+        sed -e 's/password: .*/password: "[redacted]"/' < inventory.yaml || true
+        echo ::endgroup::
+
+    - name: Install agent
+      uses: nick-invision/retry@v1
+      with:
+        timeout_minutes: 30
+        max_attempts: 5
+        retry_wait_seconds: 60
+        command: buildevents cmd $TRACE_ID $STEP_ID 'rake litmus:install_agent ${{ matrix.collection }}' -- bundle exec rake 'litmus:install_agent[${{ matrix.collection }}]'
+
+    - name: Install module
+      run: |
+        buildevents cmd $TRACE_ID $STEP_ID 'rake litmus:install_module' -- bundle exec rake 'litmus:install_module'
+
+    - name: "Honeycomb: Record deployment times"
+      if: ${{ always() }}
+      run: |
+        echo ::group::honeycomb step
+        buildevents step $TRACE_ID $STEP_ID $STEP_START 'Deploy test system'
+        echo STEP_ID=${{ matrix.platform }}-${{ matrix.collection }}-3 >> $GITHUB_ENV
+        echo STEP_START=$(date +%s) >> $GITHUB_ENV
+        echo ::endgroup::
+
+    - name: Run integration tests
+      run: |
+        buildevents cmd $TRACE_ID $STEP_ID 'rake ntp:integration' -- bundle exec rake ntp:integration
+
+    - name: "Honeycomb: Record integration testing times"
+      if: ${{ always() }}
+      run: |
+        buildevents step $TRACE_ID $STEP_ID $STEP_START 'Run integration tests'
+        echo STEP_ID=${{ matrix.platform }}-${{ matrix.collection }}-4 >> $GITHUB_ENV
+        echo STEP_START=$(date +%s) >> $GITHUB_ENV
+
+    - name: Remove test environment
+      if: ${{ always() }}
+      continue-on-error: true
+      run: |
+        if [ -f inventory.yaml ]; then
+          buildevents cmd $TRACE_ID $STEP_ID 'rake litmus:tear_down' -- bundle exec rake 'litmus:tear_down'
+          echo ::group::=== REQUEST ===
+          cat request.json || true
+          echo
+          echo ::endgroup::
+        fi
+
+    - name: "Honeycomb: Record removal times"
+      if: ${{ always() }}
+      run: |
+        buildevents step $TRACE_ID $STEP_ID $STEP_START 'Remove test environment'

--- a/.sync.yml
+++ b/.sync.yml
@@ -10,6 +10,15 @@ Gemfile:
     - gem: github_changelog_generator
 Rakefile:
   changelog_user: puppetlabs
+  extras:
+    - |
+      require 'rspec/core/rake_task'
+      namespace :kubernetes do
+        RSpec::Core::RakeTask.new(:integration) do |t|
+          t.pattern = 'spec/acceptance/**{,/*/**}/*_spec.rb'
+          t.rspec_opts = "--tag integration"
+        end
+      end
 spec/spec_helper.rb:
   mock_with: ":rspec"
   coverage_report: true

--- a/.sync.yml
+++ b/.sync.yml
@@ -13,7 +13,7 @@ Rakefile:
   extras:
     - |
       require 'rspec/core/rake_task'
-      namespace :kubernetes do
+      namespace :ntp do
         RSpec::Core::RakeTask.new(:integration) do |t|
           t.pattern = 'spec/acceptance/**{,/*/**}/*_spec.rb'
           t.rspec_opts = "--tag integration"

--- a/Rakefile
+++ b/Rakefile
@@ -86,3 +86,10 @@ EOM
   end
 end
 
+require 'rspec/core/rake_task'
+namespace :ntp do
+  RSpec::Core::RakeTask.new(:integration) do |t|
+    t.pattern = 'spec/acceptance/**{,/*/**}/*_spec.rb'
+    t.rspec_opts = "--tag integration"
+  end
+end

--- a/metadata.json
+++ b/metadata.json
@@ -15,34 +15,6 @@
   ],
   "operatingsystem_support": [
     {
-      "operatingsystem": "RedHat",
-      "operatingsystemrelease": [
-        "6",
-        "7"
-      ]
-    },
-    {
-      "operatingsystem": "CentOS",
-      "operatingsystemrelease": [
-        "6",
-        "7"
-      ]
-    },
-    {
-      "operatingsystem": "OracleLinux",
-      "operatingsystemrelease": [
-        "6",
-        "7"
-      ]
-    },
-    {
-      "operatingsystem": "Scientific",
-      "operatingsystemrelease": [
-        "6",
-        "7"
-      ]
-    },
-    {
       "operatingsystem": "SLES",
       "operatingsystemrelease": [
         "12",
@@ -55,29 +27,6 @@
         "8",
         "9",
         "10"
-      ]
-    },
-    {
-      "operatingsystem": "Ubuntu",
-      "operatingsystemrelease": [
-        "14.04",
-        "16.04",
-        "18.04",
-        "20.04"
-      ]
-    },
-    {
-      "operatingsystem": "Solaris",
-      "operatingsystemrelease": [
-        "11"
-      ]
-    },
-    {
-      "operatingsystem": "AIX",
-      "operatingsystemrelease": [
-        "5.3",
-        "6.1",
-        "7.1"
       ]
     }
   ],

--- a/metadata.json
+++ b/metadata.json
@@ -15,6 +15,34 @@
   ],
   "operatingsystem_support": [
     {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "OracleLinux",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "Scientific",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    },
+    {
       "operatingsystem": "SLES",
       "operatingsystemrelease": [
         "12",
@@ -28,6 +56,29 @@
         "9",
         "10"
       ]
+    },
+    {
+      "operatingsystem": "Ubuntu",
+      "operatingsystemrelease": [
+        "14.04",
+        "16.04",
+        "18.04",
+        "20.04"
+      ]
+    },
+    {
+      "operatingsystem": "Solaris",
+      "operatingsystemrelease": [
+        "11"
+      ]
+    },
+    {
+      "operatingsystem": "AIX",
+      "operatingsystemrelease": [
+        "5.3",
+        "6.1",
+        "7.1"
+      ]
     }
   ],
   "requirements": [
@@ -38,6 +89,6 @@
   ],
   "description": "NTP Module for Debian, Ubuntu, CentOS, RHEL, OEL, Fedora, FreeBSD, ArchLinux, Amazon Linux and Gentoo.",
   "template-url": "https://github.com/puppetlabs/pdk-templates.git#main",
-  "template-ref": "heads/main-0-g12a5dea",
-  "pdk-version": "1.18.1"
+  "template-ref": "heads/main-0-ge04486b",
+  "pdk-version": "2.0.0"
 }

--- a/plans/pe_agent.pp
+++ b/plans/pe_agent.pp
@@ -1,0 +1,18 @@
+# @summary Install PE
+#
+# Install PE Agent
+#
+# @example
+#   ntp::pe_agent
+plan ntp::pe_agent() {
+  #identify pe server and agent nodes
+  $puppet_server =  get_targets('*').filter |$n| { $n.vars['role'] == 'ntpserver' }
+  $puppet_agent =  get_targets('*').filter |$n| { $n.vars['role'] == 'ntpclient' }
+
+  # install pe server
+  run_plan(
+    'deploy_pe::provision_agent',
+    $puppet_agent,
+    'master' => $puppet_server,
+  )
+}

--- a/plans/pe_server.pp
+++ b/plans/pe_server.pp
@@ -1,0 +1,22 @@
+# @summary Install PE Server
+#
+# Install PE Server
+#
+# @example
+#   ntp::pe_server
+plan ntp::pe_server(
+  Optional[String] $version = '2019.8.5',
+  Optional[Hash] $pe_settings = {password => 'puppetlabs'}
+) {
+  #identify pe server node
+  $puppet_server =  get_targets('*').filter |$n| { $n.vars['role'] == 'ntpserver' }
+
+  # install pe server
+  run_plan(
+    'deploy_pe::provision_master',
+    $puppet_server,
+    'version' => $version,
+    'pe_settings' => $pe_settings
+  )
+}
+

--- a/plans/provision_gcp.pp
+++ b/plans/provision_gcp.pp
@@ -5,11 +5,12 @@
 # @example
 #   ntp::provision_integration
 plan ntp::provision_gcp(
-  Optional[String] $gcp_image = 'centos-7',
+  Optional[String] $image = 'centos-7',
+  Optional[String] $provision_type = 'provision_service',
 ) {
   #provision server machine, set role
-  run_task('provision::provision_service', 'localhost',
-    action => 'provision', platform => $gcp_image, vars => 'role: ntpserver')
-  run_task('provision::provision_service', 'localhost',
-    action => 'provision', platform => $gcp_image, vars => 'role: ntpclient')
+  run_task("provision::$provision_type", 'localhost',
+    action => 'provision', platform => $image, vars => 'role: ntpserver')
+  run_task("provision::$provision_type", 'localhost',
+    action => 'provision', platform => $image, vars => 'role: ntpclient')
 }

--- a/plans/provision_gcp.pp
+++ b/plans/provision_gcp.pp
@@ -1,0 +1,15 @@
+# @summary Provisions machines
+#
+# Provisions machines for integration testing
+#
+# @example
+#   ntp::provision_integration
+plan ntp::provision_gcp(
+  Optional[String] $gcp_image = 'centos-7',
+) {
+  #provision server machine, set role
+  run_task('provision::provision_service', 'localhost',
+    action => 'provision', platform => $gcp_image, vars => 'role: ntpserver')
+  run_task('provision::provision_service', 'localhost',
+    action => 'provision', platform => $gcp_image, vars => 'role: ntpclient')
+}

--- a/spec/acceptance/integration_ntp_spec.rb
+++ b/spec/acceptance/integration_ntp_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'spec_helper_acceptance'
+require 'json'
+require 'pry'
+
+describe 'we are able to setup an ntp server, and connect a client to it', :integration do
+  context 'set up the server' do
+    before(:all) { change_target_host('ntpserver') }
+    after(:all) { reset_target_host }
+    servicename = if os[:family] == 'sles' && os[:release].start_with?('12', '15')
+                    'ntpd'
+                  else
+                    'ntp'
+                  end
+    describe 'set up ntpserver' do
+      it 'check the date is 2021' do
+        result = run_shell('date')
+        expect(result.stdout).to match(%r{2021})
+      end
+      pp = <<-MANIFEST
+      class { 'ntp': }
+      MANIFEST
+      it 'sets up the service' do
+        idempotent_apply(pp)
+        expect(service(servicename)).to be_running
+        expect(service(servicename)).to be_enabled
+      end
+    end
+  end
+  context 'set up the client' do
+    before(:all) { change_target_host('ntpclient') }
+    after(:all) { reset_target_host }
+    describe 'go to the future' do
+      it 'its 2021' do
+        result = run_shell('date')
+        expect(result.stdout).to match(%r{2021})
+      end
+      it 'install ntpdate' do
+        apply_manifest("package { 'ntpdate': ensure => present }")
+      end
+      it 'disable ntp auto-sync' do
+        result = run_shell('timedatectl set-ntp false')
+        expect(result.exit_code).to eq(0)
+      end
+      it 'go forward to 2022' do
+        result = run_shell('date --set="$(date --date="next year")"')
+        expect(result.stdout).to match(%r{2022})
+        expect(result.exit_code).to eq(0)
+      end
+      it 'changed 2022' do
+        result = run_shell('date')
+        expect(result.stdout).to match(%r{2022})
+      end
+    end
+  end
+end

--- a/spec/acceptance/integration_ntp_spec.rb
+++ b/spec/acceptance/integration_ntp_spec.rb
@@ -8,11 +8,6 @@ describe 'we are able to setup an ntp server, and connect a client to it', :inte
   context 'set up the server' do
     before(:all) { change_target_host('ntpserver') }
     after(:all) { reset_target_host }
-    servicename = if os[:family] == 'sles' && os[:release].start_with?('12', '15')
-                    'ntpd'
-                  else
-                    'ntp'
-                  end
     describe 'set up ntpserver' do
       it 'check the date is 2021' do
         result = run_shell('date')
@@ -23,8 +18,6 @@ describe 'we are able to setup an ntp server, and connect a client to it', :inte
       MANIFEST
       it 'sets up the service' do
         idempotent_apply(pp)
-        expect(service(servicename)).to be_running
-        expect(service(servicename)).to be_enabled
       end
     end
   end

--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -3,3 +3,34 @@
 include PuppetLitmus
 
 UNSUPPORTED_PLATFORMS = ['windows', 'darwin'].freeze
+
+def inventory_hash
+  @inventory_hash ||= inventory_hash_from_inventory_file
+end
+
+def target_roles(roles)
+  # rubocop:disable Style/MultilineBlockChain
+  inventory_hash['groups'].map { |group|
+    group['targets'].map { |node|
+      { name: node['uri'], role: node['vars']['role'] } if roles.include? node['vars']['role']
+    }.reject { |val| val.nil? }
+  }.flatten
+  # rubocop:enable Style/MultilineBlockChain
+end
+
+RSpec.configure do |config|
+  if config.filter.rules.key? :integration
+    ENV['TARGET_HOST'] = target_roles('ntpserver')[0][:name]
+  else
+    config.filter_run_excluding :integration
+  end
+end
+
+def change_target_host(role)
+  @orig_target_host = ENV['TARGET_HOST']
+  ENV['TARGET_HOST'] = target_roles(role)[0][:name]
+end
+
+def reset_target_host
+  ENV['TARGET_HOST'] = @orig_target_host
+end


### PR DESCRIPTION
Testing the multi node setup on gcp.
- Create separate workflow for integration tests (platforms, agent inform collected from metadata)
- How many nodes to provision based on the provision plans created for the module
- Retry mechanism is now been called only from provision task hence the install_agent was failing
- Added retry mechanism to install_agent for the workaround
- The following file changes are picked up from TPs work (Rakefile, provision_gcp.pp, spec_helper_acceptance_local, integration_ntp_spec  https://github.com/tphoney/puppetlabs-ntp/tree/IAC-1368
- integration_ntp_spec is a sample test created to run on ubuntu. It's  modified to run on sles system too.
- This PR tests it can provision multiple nodes and execute tests on specific target hosts on GCP
- - Installed PE on node and respective agents using plans from https://github.com/jarretlavallee/puppet-deploy_pe/tree/master/plans