### PR TITLE
pdksync - Remove Puppet 5 from testing and bump minimal version to 6.0.0

### DIFF
--- a/.github/workflows/auto_release.yml
+++ b/.github/workflows/auto_release.yml
@@ -1,0 +1,81 @@
+name: "Auto release"
+
+on:
+  schedule:
+    - cron: '0 3 * * 6'
+  workflow_dispatch:
+
+env:
+  HONEYCOMB_WRITEKEY: 7f3c63a70eecc61d635917de46bea4e6 
+  HONEYCOMB_DATASET: litmus tests
+  CHANGELOG_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  auto_release:
+    name: "Automatic release prep"
+    runs-on: ubuntu-20.04
+
+    steps:
+    - name: "Honeycomb: Start recording"
+      uses: puppetlabs/kvrhdn-gha-buildevents@pdk-templates-v1
+      with:
+        apikey: ${{ env.HONEYCOMB_WRITEKEY }}
+        dataset: ${{ env.HONEYCOMB_DATASET }}
+        job-status: ${{ job.status }}
+
+    - name: "Honeycomb: start first step"
+      run: |
+        echo STEP_ID="auto-release" >> $GITHUB_ENV
+        echo STEP_START=$(date +%s) >> $GITHUB_ENV
+
+    - name: "Checkout Source"
+      if: ${{ github.repository_owner == 'puppetlabs' }}
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        persist-credentials: false
+
+    - name: "PDK Release prep"
+      uses: docker://puppet/pdk:nightly
+      with:
+        args: 'release prep --force'
+      env:
+        CHANGELOG_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: "Get Version"
+      if: ${{ github.repository_owner == 'puppetlabs' }}
+      id: gv
+      run: |
+        echo "::set-output name=ver::$(cat metadata.json | jq .version | tr -d \")"
+
+    - name: "Commit changes"
+      if: ${{ github.repository_owner == 'puppetlabs' }}
+      run: |
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
+        git add .
+        git commit -m "Release prep v${{ steps.gv.outputs.ver }}"
+
+    - name: Create Pull Request
+      id: cpr
+      uses: puppetlabs/peter-evans-create-pull-request@v3
+      if: ${{ github.repository_owner == 'puppetlabs' }}
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        commit-message: "Release prep v${{ steps.gv.outputs.ver }}"
+        branch: "release-prep"
+        delete-branch: true
+        title: "Release prep v${{ steps.gv.outputs.ver }}"
+        body: "Automated release-prep through [pdk-templates](https://github.com/puppetlabs/pdk-templates/blob/main/moduleroot/.github/workflows/auto_release.yml.erb)"
+        labels: "maintenance"
+
+    - name: PR outputs
+      if: ${{ github.repository_owner == 'puppetlabs' }}
+      run: |
+        echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
+        echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"
+
+    - name: "Honeycomb: Record finish step"
+      if: ${{ always() }}
+      run: |
+        buildevents step $TRACE_ID $STEP_ID $STEP_START 'Finished auto release workflow'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,6 +29,9 @@ RSpec/BeforeAfterAll:
 RSpec/HookArgument:
   Description: Prefer explicit :each argument, matching existing module's style
   EnforcedStyle: each
+RSpec/DescribeSymbol:
+  Exclude:
+  - spec/unit/facter/**/*.rb
 Style/BlockDelimiters:
   Description: Prefer braces for chaining. Mostly an aesthetical choice. Better to
     be consistent then.
@@ -403,6 +406,8 @@ Style/ExplicitBlockArgument:
 Style/ExponentialNotation:
   Enabled: false
 Style/FloatDivision:
+  Enabled: false
+Style/FrozenStringLiteralComment:
   Enabled: false
 Style/GlobalStdStream:
   Enabled: false

--- a/.sync.yml
+++ b/.sync.yml
@@ -21,11 +21,6 @@
         - puppet6
         provision_list:
         - travis_ub_6
-    - collection:
-        puppet_collection:
-        - puppet5
-        provision_list:
-        - travis_ub_5
   simplecov: true
   notifications:
     slack:

--- a/.sync.yml
+++ b/.sync.yml
@@ -44,3 +44,5 @@ spec/spec_helper.rb:
   unmanaged: false
 .github/workflows/pr_test.yml:
   unmanaged: false
+.github/workflows/auto_release.yml:
+  unmanaged: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,39 +39,6 @@ jobs:
       services: docker
       stage: acceptance
     - before_script:
-      - "bundle exec rake 'litmus:provision_list[travis_ub_5]'"
-      - "bundle exec rake 'litmus:install_agent[puppet5]'"
-      - "bundle exec rake litmus:install_module"
-      env:
-        PLATFORMS: travis_ub_5_puppet5
-        BUNDLE_WITH: system_tests
-      rvm: 2.5.7
-      script: ["travis_wait 45 bundle exec rake litmus:acceptance:parallel"]
-      services: docker
-      stage: acceptance
-    - before_script:
-      - "bundle exec rake 'litmus:provision_list[travis_deb]'"
-      - "bundle exec rake 'litmus:install_agent[puppet5]'"
-      - "bundle exec rake litmus:install_module"
-      env:
-        PLATFORMS: travis_deb_puppet5
-        BUNDLE_WITH: system_tests
-      rvm: 2.5.7
-      script: ["travis_wait 45 bundle exec rake litmus:acceptance:parallel"]
-      services: docker
-      stage: acceptance
-    - before_script:
-      - "bundle exec rake 'litmus:provision_list[travis_el7]'"
-      - "bundle exec rake 'litmus:install_agent[puppet5]'"
-      - "bundle exec rake litmus:install_module"
-      env:
-        PLATFORMS: travis_el7_puppet5
-        BUNDLE_WITH: system_tests
-      rvm: 2.5.7
-      script: ["travis_wait 45 bundle exec rake litmus:acceptance:parallel"]
-      services: docker
-      stage: acceptance
-    - before_script:
       - "bundle exec rake 'litmus:provision_list[travis_deb]'"
       - "bundle exec rake 'litmus:install_agent[puppet6]'"
       - "bundle exec rake litmus:install_module"
@@ -96,10 +63,6 @@ jobs:
     -
       env: CHECK="check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop syntax lint metadata_lint"
       stage: static
-    -
-      env: PUPPET_GEM_VERSION="~> 5.0" CHECK=parallel_spec
-      rvm: 2.4.5
-      stage: spec
     -
       env: PUPPET_GEM_VERSION="~> 6.0" CHECK=parallel_spec
       rvm: 2.5.7

--- a/metadata.json
+++ b/metadata.json
@@ -93,6 +93,6 @@
   ],
   "description": "NTP Module for Debian, Ubuntu, CentOS, RHEL, OEL, Fedora, FreeBSD, ArchLinux, Amazon Linux and Gentoo.",
   "template-url": "https://github.com/puppetlabs/pdk-templates.git#main",
-  "template-ref": "heads/main-0-g1862b96",
-  "pdk-version": "1.19.0.pre (47)"
+  "template-ref": "heads/main-0-g44cc7ed",
+  "pdk-version": "1.18.1"
 }

--- a/metadata.json
+++ b/metadata.json
@@ -88,7 +88,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 5.5.10 < 8.0.0"
+      "version_requirement": ">= 6.0.0 < 8.0.0"
     }
   ],
   "description": "NTP Module for Debian, Ubuntu, CentOS, RHEL, OEL, Fedora, FreeBSD, ArchLinux, Amazon Linux and Gentoo.",

--- a/provision.yaml
+++ b/provision.yaml
@@ -14,12 +14,6 @@ travis_deb:
   - litmusimage/debian:8
   - litmusimage/debian:9
   - litmusimage/debian:10
-travis_ub_5:
-  provisioner: docker
-  images:
-  - litmusimage/ubuntu:14.04
-  - litmusimage/ubuntu:16.04
-  - litmusimage/ubuntu:18.04
 travis_ub_6:
   provisioner: docker
   images:
@@ -33,26 +27,6 @@ travis_el7:
   - litmusimage/centos:7
   - litmusimage/oraclelinux:7
   - litmusimage/scientificlinux:7
-release_checks_5:
-  provisioner: abs
-  images:
-  - redhat-6-x86_64
-  - redhat-7-x86_64
-  - centos-6-x86_64
-  - centos-7-x86_64
-  - oracle-5-x86_64
-  - oracle-6-x86_64
-  - oracle-7-x86_64
-  - scientific-6-x86_64
-  - scientific-7-x86_64
-  - debian-8-x86_64
-  - debian-9-x86_64
-  - debian-10-x86_64
-  - sles-12-x86_64
-  - sles-15-x86_64
-  - ubuntu-1404-x86_64
-  - ubuntu-1604-x86_64
-  - ubuntu-1804-x86_64
 release_checks_6:
   provisioner: abs
   images:


### PR DESCRIPTION
Remove Puppet 5 from testing and bump minimal version to 6.0.0
pdk version: `1.19.0.pre (47)` 
