### PR TITLE
Allow setting user and group permissions of the NTP logfile

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -26,7 +26,9 @@ ntp::keys_trusted: []
 ntp::keys: []
 ntp::leapfile: ~
 ntp::logfile: ~
+ntp::logfile_user: 'ntp'
 ntp::logfile_mode: '0664'
+ntp::logfile_group: 'ntp'
 ntp::logconfig: ~
 ntp::ntpsigndsocket: ~
 ntp::maxpoll: ~

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -139,8 +139,8 @@ class ntp::config {
   if $ntp::logfile {
     file { $ntp::logfile:
       ensure => file,
-      owner  => 'ntp',
-      group  => 'ntp',
+      owner  => $ntp::logfile_user,
+      group  => $ntp::logfile_group,
       mode   => $ntp::logfile_mode,
     }
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -87,9 +87,15 @@
 #
 # @param logfile
 #   Specifies a log file for NTP to use instead of syslog. Default value: ' '.
-
+#
+# @param logfile_group
+#   Specifies the group for the NTP log file. Default is 'ntp'.
+#
 # @param logfile_mode
 #   Specifies the permission for the NTP log file. Default is 0664.
+#
+# @param logfile_user
+#   Specifies the user for the NTP log file. Default is 'ntp'.
 #
 # @param logconfig
 #   Specifies the logconfig for NTP to use. Default value: ' '.
@@ -248,7 +254,9 @@ class ntp (
   Stdlib::Absolutepath $driftfile,
   Optional[Stdlib::Absolutepath] $leapfile,
   Optional[Stdlib::Absolutepath] $logfile,
+  Optional[Variant[String, Integer]] $logfile_group,
   String $logfile_mode,
+  Optional[Variant[String, Integer]] $logfile_user,
   Optional[String] $logconfig,
   Boolean $iburst_enable,
   Array[String] $keys,


### PR DESCRIPTION
The Puppet file resource `manifests/config.pp` assumes that the user and group `ntp` exist on all supported operating systems. This is not the case (at least) for AIX 7.1, AIX 7.2, and Solaris 11. This results in the Puppet agent run failing to modify the user and group permissions of `$ntp::logfile`.

I'm proposing that the user and group values be turned into parameters, with the default user and group in `data/common.yaml` remaining as `ntp` as to not break any existing configurations.