### PR TITLE
pdksync - (IAC-1787) Remove Support for CentOS 6

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -24,7 +24,6 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "6",
         "7"
       ]
     },


### PR DESCRIPTION
(IAC-1787) Remove Support for CentOS 6
pdk version: `2.1.0` 
