### PR TITLE
SMF service instance change in Oracle Solaris 11.4 SRU 45.119.2

### DIFF
--- a/data/Solaris-11.yaml
+++ b/data/Solaris-11.yaml
@@ -7,5 +7,5 @@ ntp::restrict:
   - '-6 default kod nomodify notrap nopeer noquery'
   - '127.0.0.1'
   - '-6 ::1'
-ntp::service_name: 'network/ntp'
+ntp::service_name: 'network/ntp:default'
 ntp::iburst_enable: false


### PR DESCRIPTION
Oracle Solaris 11.4 SRU 45.119.2 adds a new SMF service for NTP monitoring `svc:/network/ntp:monitor`.

This results in the ntp module failing with the following error:
```
Error: /Stage[main]/Ntp::Service/Service[ntp]: Could not evaluate: Failed to get the FMRI of the network/ntp service: The pattern 'network/ntp' matches multiple FMRIs! These are the FMRIs it matches: svc:/network/ntp:default, svc:/network/ntp:monitor
```

This change updates `ntp::service_name` to specifically reference the default instance.