### PR TITLE
(MAINT) Removal of support for AIX 5.3 & 6.1

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -73,8 +73,6 @@
     {
       "operatingsystem": "AIX",
       "operatingsystemrelease": [
-        "5.3",
-        "6.1",
         "7.1"
       ]
     }


### PR DESCRIPTION
Prior to this commit the metadata.json file for this module listed OSs that are not supported by puppet agent as supported. This commit aims to refactor the metadata.json file to only list OSs that are supported by puppet agent.

In this commit:
Support for AIX 5.3 and 6.1 was removed.

The list of supported OSs can be found here:
https://puppet.com/docs/pe/2021.7/supported_operating_systems.html