### PR TITLE
pdksync - (CONT-189) Remove support for RedHat6 / OracleLinux6 / Scientific6

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -29,7 +29,6 @@
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
-        "6",
         "7"
       ]
     },

--- a/metadata.json
+++ b/metadata.json
@@ -35,7 +35,6 @@
     {
       "operatingsystem": "Scientific",
       "operatingsystemrelease": [
-        "6",
         "7"
       ]
     },

--- a/metadata.json
+++ b/metadata.json
@@ -17,7 +17,6 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "6",
         "7"
       ]
     },


### PR DESCRIPTION
CONT-189/remove_os_support
pdk version: `2.4.0` 
