### PR TITLE
(CONT-204) Adding mend config

### DIFF
--- a/.github/workflows/mend.yml
+++ b/.github/workflows/mend.yml
@@ -1,0 +1,18 @@
+name: "mend"
+
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+    branches:
+      - "main"
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+jobs:
+
+  mend:
+    uses: "puppetlabs/cat-github-actions/.github/workflows/mend_ruby.yml@main"
+    secrets: "inherit"


### PR DESCRIPTION
Prior to this commit, mend config did not exist, therefore the repo was not being scanned for vulnerabilities.

Adding this config will set up vulnerability scanning using the tool mend.