### PR TITLE
minimum value for poll interval should be 3, not 4

### DIFF
--- a/types/poll_interval.pp
+++ b/types/poll_interval.pp
@@ -1,3 +1,3 @@
-# See http://doc.ntp.org/4.2.6/clockopt.html#server for documentation
+# See https://doc.ntp.org/documentation/4.2.6-series/confopt/#command-options for documentation
 # Alternatively: type Ntp::Poll_interval = Variant[Integer, Pattern['']]
-type Ntp::Poll_interval = Integer[4, 17]
+type Ntp::Poll_interval = Integer[3, 17]


### PR DESCRIPTION
Hi Team

Just migrating over to using the ntp forge module, and found this little nit

`minpoll` should be allowed to be 3, per the ntp documentation https://doc.ntp.org/documentation/4.2.6-series/confopt/#command-options, and 3 is even described as the lower range in https://github.com/puppetlabs/puppetlabs-ntp/blob/main/manifests/init.pp#L105