### PR TITLE
(CONT-404) Address set-output deprecation

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -55,9 +55,9 @@ jobs:
       id: get-matrix
       run: |
         if [ '${{ github.repository_owner }}' == 'puppetlabs' ]; then
-          echo  "::set-output name=matrix::{'platform':['centos-7'],'collection':['puppet6-nightly']}"
+          echo  "matrix={'platform':['centos-7'],'collection':['puppet6-nightly']}" >> $GITHUB_OUTPUT
         else
-          echo  "::set-output name=matrix::{}"
+          echo  "matrix={}"  >> $GITHUB_OUTPUT
         fi
 
     - name: "Honeycomb: Record Setup Test Matrix time"


### PR DESCRIPTION
Prior to this commit, this module contained a set-output command in the integration_test.yml file. This is a deprecated github command that will stop working by the end of may.

This commit aims to update the command so that it does not break once the syntax is fully deprecated.