### PR TITLE
(maint) Update integration_test.yml puppet version

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -32,7 +32,7 @@ jobs:
       id: get-matrix
       run: |
         if [ '${{ github.repository_owner }}' == 'puppetlabs' ]; then
-          echo  "matrix={'platform':['centos-7'],'collection':['puppet6-nightly']}" >> $GITHUB_OUTPUT
+          echo  "matrix={'platform':['centos-7'],'collection':['puppet7-nightly']}" >> $GITHUB_OUTPUT
         else
           echo  "matrix={}"  >> $GITHUB_OUTPUT
         fi

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -32,7 +32,7 @@ jobs:
       id: get-matrix
       run: |
         if [ '${{ github.repository_owner }}' == 'puppetlabs' ]; then
-          echo  "matrix={'platform':['centos-7'],'collection':['puppet7-nightly']}" >> $GITHUB_OUTPUT
+          echo  "matrix={'platform':['centos-7'],'collection':['puppet8-nightly']}" >> $GITHUB_OUTPUT
         else
           echo  "matrix={}"  >> $GITHUB_OUTPUT
         fi


### PR DESCRIPTION
Prior to this commit, the integration was running on puppet6 which is EOL. 

This commit updates integration testing to run on a newer version of puppet.