### PR TITLE
(CONT-903) Use checkout@v3

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
     - name: Checkout Source
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       if: ${{ github.repository_owner == 'puppetlabs' }}
 
     - name: Activate Ruby 2.7
@@ -50,7 +50,7 @@ jobs:
     steps:
 
     - name: Checkout Source
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Activate Ruby 2.7
       uses: ruby/setup-ruby@v1


### PR DESCRIPTION
Prior to this commit, the integration test workflow had deprecation warnings because it was using the checkout v2 workflow rather than v3. This commit replaces v2 with v3