### PR TITLE
(maint) - remove `runs_on` input from integration job

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -22,5 +22,3 @@ jobs:
   Integration:
     needs: Acceptance
     uses: "./.github/workflows/integration_test.yml"
-    with:
-      runs_on: "ubuntu-20.04"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -20,5 +20,5 @@ jobs:
     secrets: "inherit"
 
   Integration:
-    needs: Acceptance
+    needs: Spec
     uses: "./.github/workflows/integration_test.yml"


### PR DESCRIPTION
Fixes https://github.com/puppetlabs/puppetlabs-ntp/actions/runs/5008997369
Removes the `acceptance` job dependency from the `integration` job due to the likelihood of failed provisioning, resulting in unran integration tests.