### PR TITLE
(MAINT) - Enable legacy repo for SUSE 15 SP4

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -5,6 +5,14 @@
 #
 class ntp::install {
   if $ntp::package_manage {
+    if ($facts['os']['name'] == 'SLES' and $facts['os']['release']['major'] == '15') {
+      exec { 'Enable legacy repos':
+        path    => '/bin:/usr/bin/:/sbin:/usr/sbin',
+        command => '/usr/bin/SUSEConnect --product sle-module-legacy/15.4/x86_64',
+        unless  => 'SUSEConnect --status-text | grep sle-module-legacy/15.4/x86_64',
+      }
+    }
+
     package { $ntp::package_name:
       ensure => $ntp::package_ensure,
     }


### PR DESCRIPTION
## Summary


Enable legacy SP3 repo so that we can leverage the old packages without any issues.

## Additional Context

New release of SUSE 15 introduced new version SP4 which deprecated old packages where `ntp` is one of them. As the package is deprecated with SP4 repo so user will not able to install.

## Related Issues (if any)
Due to package got deprecated from new repo, respective package manager is not able to install.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)