### PR TITLE
(CAT-1204) - CI pipeline fix for SLES OS

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -8,8 +8,8 @@ class ntp::install {
     if ($facts['os']['name'] == 'SLES' and $facts['os']['release']['major'] == '15') {
       exec { 'Enable legacy repos':
         path    => '/bin:/usr/bin/:/sbin:/usr/sbin',
-        command => '/usr/bin/SUSEConnect --product sle-module-legacy/15.4/x86_64',
-        unless  => 'SUSEConnect --status-text | grep sle-module-legacy/15.4/x86_64',
+        command => '/usr/bin/SUSEConnect --product sle-module-legacy/15.5/x86_64',
+        unless  => 'SUSEConnect --status-text | grep sle-module-legacy/15.5/x86_64',
       }
     }
 


### PR DESCRIPTION
## Summary
Enable legacy SP5 repo so that we can leverage the old packages without any issues.

## Additional Context
Add any additional context about the problem here. 
New release of SUSE introduced new version SP5 which deprecated old apache2-mod_php7 package. As the package is deprecated with old SP4 repo so user will not able to install.

## Related Issues (if any)
Due to package got deprecated from new repo, respective package manager is not able to install. This also affects the modules that is using java internally as a dependency or to install packages.

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)