### PR TITLE
pdksync - (CAT-343) Audit modules and tools for references to travis. Removed all needless references to travis.

### DIFF
--- a/provision.yaml
+++ b/provision.yaml
@@ -8,20 +8,20 @@ vagrant:
   images:
   - centos/7
   - generic/ubuntu1804
-travis_deb:
+docker_deb:
   provisioner: docker_exp
   images:
   - litmusimage/debian:8
   - litmusimage/debian:9
   - litmusimage/debian:10
-travis_ub_6:
+docker_ub_6:
   provisioner: docker
   images:
   - litmusimage/ubuntu:14.04
   - litmusimage/ubuntu:16.04
   - litmusimage/ubuntu:18.04
   - litmusimage/ubuntu:20.04
-travis_el7:
+docker_el7:
   provisioner: docker_exp
   images:
   - litmusimage/centos:7


### PR DESCRIPTION
(CAT-343) Audit modules and tools for references to travis. Removed all needless references to travis.
pdk version: `2.7.1` 
