### PR TITLE
Add package and service name for Debian 12 'ntpsec'

### DIFF
--- a/data/Debian-12.yaml
+++ b/data/Debian-12.yaml
@@ -1,0 +1,3 @@
+---
+ntp::service_name: 'ntpsec'
+ntp::package_name: [ 'ntpsec' ]


### PR DESCRIPTION
## Summary

Added one file in data to match Debian-12 hosts.

## Additional Context

"ntp" is now a transitional dummy package in Debian and a Puppet run with the service enabled will fail since the service "ntp" is renamed to "ntpsec".
