### PR TITLE
(CAT-2052) Bump sles-module-legacy from 15.5 to 15.6

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -8,8 +8,8 @@ class ntp::install {
     if ($facts['os']['name'] == 'SLES' and $facts['os']['release']['major'] == '15') {
       exec { 'Enable legacy repos':
         path    => '/bin:/usr/bin/:/sbin:/usr/sbin',
-        command => '/usr/bin/SUSEConnect --product sle-module-legacy/15.5/x86_64',
-        unless  => 'SUSEConnect --status-text | grep sle-module-legacy/15.5/x86_64',
+        command => '/usr/bin/SUSEConnect --product sle-module-legacy/15.6/x86_64',
+        unless  => 'SUSEConnect --status-text | grep sle-module-legacy/15.6/x86_64',
       }
     }
 


### PR DESCRIPTION
## Summary
Bump sles-module-legacy product from 15.5 to 15.6 as 15.5 is no more available in SUSEConnect extensions. 

## Additional Context
This resolves the nightly failures for SLES-15 (puppet-7 and puppet8)

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)