### PR TITLE
(CAT-2090) Replace centos-7 with ubuntu-2204-amd for integration tests

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -37,7 +37,7 @@ jobs:
       id: get-matrix
       run: |
         if [ '${{ github.repository_owner }}' == 'puppetlabs' ]; then
-          echo  "matrix={'platform':['centos-7'],'collection':['puppet7-nightly', 'puppet8-nightly']}" >> $GITHUB_OUTPUT
+          echo  "matrix={'platform':['ubuntu-2204-lts'],'collection':['puppet7-nightly', 'puppet8-nightly']}" >> $GITHUB_OUTPUT
         else
           echo  "matrix={}"  >> $GITHUB_OUTPUT
         fi

--- a/plans/acceptance/pe_server.pp
+++ b/plans/acceptance/pe_server.pp
@@ -5,7 +5,7 @@
 # @example
 #   ntp::acceptance::pe_server
 plan ntp::acceptance::pe_server(
-  Optional[String] $version = '2019.8.5',
+  Optional[String] $version = '2021.7.9',
   Optional[Hash] $pe_settings = { password => 'puppetlabs' }
 ) {
   #identify pe server node


### PR DESCRIPTION
## Summary
Replace centos-7 with ubuntu-2204-amd for integration tests since centos-7 is no longer supported in PE.

## Additional Context
We cannot migrate to centos-8 or centos-9 since those have deprecated ntp in favour of chrony. Updated pe_server version from 2019.8.5 to 2021.7.9 since the older one did not support PE for Ubuntu 2404.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)