### PR TITLE
(CAT-2296) Update github runner image to ubuntu-24.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,12 +10,12 @@ jobs:
   Spec:
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_ci.yml@main"
     with:
-      runs_on: "ubuntu-20.04"
+      runs_on: "ubuntu-24.04"
     secrets: "inherit"
 
   Acceptance:
     needs: Spec
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_acceptance.yml@main"
     with:
-      runs_on: "ubuntu-20.04"
+      runs_on: "ubuntu-24.04"
     secrets: "inherit"

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   setup_matrix:
     name: "Setup Test Matrix"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     outputs:
       matrix: ${{ steps.get-matrix.outputs.matrix }}
 
@@ -47,7 +47,7 @@ jobs:
       - setup_matrix
     if: ${{ needs.setup_matrix.outputs.matrix != '{}' }}
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix: ${{fromJson(needs.setup_matrix.outputs.matrix)}}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,14 +9,14 @@ jobs:
   Spec:
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_ci.yml@main"
     with:
-      runs_on: "ubuntu-20.04"
+      runs_on: "ubuntu-24.04"
     secrets: "inherit"
 
   Acceptance:
     needs: Spec
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_acceptance.yml@main"
     with:
-      runs_on: "ubuntu-20.04"
+      runs_on: "ubuntu-24.04"
     secrets: "inherit"
 
   Integration:


### PR DESCRIPTION
ubuntu-20.04 is not supported anymore: https://github.com/actions/runner-images/issues/11101

## Summary
Provide a detailed description of all the changes present in this pull request.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)