### PR TITLE
(MAINT) Fix nightly failures

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -20,7 +20,3 @@ jobs:
       runs_on: "ubuntu-24.04"
       flags: "--nightly --platform-exclude centos-7 --platform-exclude oraclelinux-7 --platform-exclude scientific-7"
     secrets: "inherit"
-
-  Integration:
-    needs: Spec
-    uses: "./.github/workflows/integration_test.yml"


### PR DESCRIPTION
During the last update, we forgot to remove the unsupported integration testing from the nightly workflow.

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
