### PR TITLE
(MAINT) Remove --nightly flag from Spec job matrix setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,6 @@ jobs:
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_ci.yml@main"
     with:
       runs_on: "ubuntu-24.04"
-      flags: "--nightly"
     secrets: "inherit"
 
   Acceptance:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -10,7 +10,6 @@ jobs:
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_ci.yml@main"
     with:
       runs_on: "ubuntu-24.04"
-      flags: "--nightly"
     secrets: "inherit"
 
   Acceptance:


### PR DESCRIPTION
## Summary
- The `Spec` job in both `ci.yml` and `nightly.yml` passes `flags: "--nightly"` into `module_ci.yml`'s `Setup Spec Test Matrix` step, which runs `bundle exec matrix_from_metadata_v3 --nightly`.
- `--nightly` is only supported by `matrix_from_metadata_v3` in `puppet_litmus ~> 2.0`. The Gemfile only installs that version when `PUPPET_FORGE_TOKEN` is present; otherwise it falls back to `puppet_litmus ~> 1.0`, whose copy of the script doesn't know the flag.
- Fork PRs (e.g. community contributions) don't receive `PUPPET_FORGE_TOKEN`, so their `Spec` job fails immediately with `Error: invalid option: --nightly`, before any actual tests run.
- The upstream `pdk-templates` `ci.yml.erb`/`nightly.yml.erb` never pass `flags` to the `Spec` job — only `Acceptance` gets flags (driven by `acceptance_flags` config). Other modules on the current template (e.g. `puppetlabs-postgresql`) follow this pattern. `--nightly` on the `Spec` job here appears to be an unintentional divergence.
- This PR removes `flags: "--nightly"` from the `Spec` job in both workflows. The `Acceptance` job's flags (including `--nightly` and the platform excludes) are untouched, since those are legitimate, intentional per-module customization.

## Test plan
- [ ] Confirm `Spec` job's "Setup Spec Test Matrix" step succeeds on a PR from a fork (no `PUPPET_FORGE_TOKEN` available)
- [ ] Confirm nightly scheduled run still succeeds as before
- [ ] Confirm `Acceptance` job still runs against nightly Puppet builds with the existing platform excludes